### PR TITLE
JWT 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.google.guava:guava:23.0'
+    implementation 'com.auth0:java-jwt:3.18.2'
+    compileOnly 'org.apache.commons:commons-lang3:3.12.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/org/ahpuh/backend/config/JwtConfig.java
+++ b/src/main/java/org/ahpuh/backend/config/JwtConfig.java
@@ -1,0 +1,22 @@
+package org.ahpuh.backend.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "jwt")
+public class JwtConfig {
+
+    private String header;
+
+    private String issuer;
+
+    private String clientSecret;
+
+    private int expirySeconds;
+
+}

--- a/src/main/java/org/ahpuh/backend/config/WebSecurityConfig.java
+++ b/src/main/java/org/ahpuh/backend/config/WebSecurityConfig.java
@@ -1,0 +1,111 @@
+package org.ahpuh.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.ahpuh.backend.jwt.Jwt;
+import org.ahpuh.backend.jwt.JwtAuthenticationFilter;
+import org.ahpuh.backend.jwt.JwtAuthenticationProvider;
+import org.ahpuh.backend.user.service.UserServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Configuration
+@EnableWebSecurity
+@Slf4j
+@RequiredArgsConstructor
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtConfig jwtConfig;
+
+    @Override
+    public void configure(final WebSecurity web) {
+        web.ignoring().antMatchers("/assets/**", "/h2-console/**");
+    }
+
+    @Bean
+    public AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, e) -> {
+            final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            final Object principal = authentication != null ? authentication.getPrincipal() : null;
+            log.error("{} is denied", principal, e);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().write("ACCESS DENIED");
+            response.getWriter().flush();
+            response.getWriter().close();
+        };
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public Jwt jwt() {
+        return new Jwt(
+                jwtConfig.getIssuer(),
+                jwtConfig.getClientSecret(),
+                jwtConfig.getExpirySeconds()
+        );
+    }
+
+    @Bean
+    public JwtAuthenticationProvider jwtAuthenticationProvider(final UserServiceImpl userService, final Jwt jwt) {
+        return new JwtAuthenticationProvider(jwt, userService);
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        final Jwt jwt = getApplicationContext().getBean(Jwt.class);
+        return new JwtAuthenticationFilter(jwtConfig.getHeader(), jwt);
+    }
+
+    @Override
+    protected void configure(final HttpSecurity http) throws Exception {
+        http
+                .authorizeRequests()
+                .antMatchers("/users/me").hasAnyRole("USER")
+                .anyRequest().permitAll()
+                .and()
+                .headers()
+                .disable()
+                .csrf()
+                .disable()
+                .formLogin()
+                .disable()
+                .httpBasic()
+                .disable()
+                .rememberMe()
+                .disable()
+                .logout()
+                .disable()
+                .exceptionHandling()
+                .accessDeniedHandler(accessDeniedHandler())
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .addFilterAfter(jwtAuthenticationFilter(), SecurityContextPersistenceFilter.class)
+        ;
+    }
+}

--- a/src/main/java/org/ahpuh/backend/jwt/Jwt.java
+++ b/src/main/java/org/ahpuh/backend/jwt/Jwt.java
@@ -43,7 +43,8 @@ public class Jwt {
         if (expirySeconds > 0) {
             builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
         }
-        builder.withClaim("username", claims.username);
+        builder.withClaim("user_id", claims.userId);
+        builder.withClaim("email", claims.email);
         builder.withArrayClaim("roles", claims.roles);
         return builder.sign(algorithm);
     }
@@ -55,15 +56,19 @@ public class Jwt {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     static public class Claims {
 
-        String username;
+        Long userId;
+        String email;
         String[] roles;
         Date iat; // 토큰 발급 시각
         Date exp; // 만료시간이 지난 토큰은 사용불가
 
         Claims(final DecodedJWT decodedJWT) {
-            final Claim username = decodedJWT.getClaim("username");
-            if (!username.isNull())
-                this.username = username.asString();
+            final Claim userId = decodedJWT.getClaim("user_id");
+            if (!userId.isNull())
+                this.userId = userId.asLong();
+            final Claim email = decodedJWT.getClaim("email");
+            if (!email.isNull())
+                this.email = email.asString();
             final Claim roles = decodedJWT.getClaim("roles");
             if (!roles.isNull()) {
                 this.roles = roles.asArray(String.class);
@@ -72,9 +77,10 @@ public class Jwt {
             this.exp = decodedJWT.getExpiresAt();
         }
 
-        public static Claims from(final String username, final String[] roles) {
+        public static Claims from(final Long userId, final String email, final String[] roles) {
             final Claims claims = new Claims();
-            claims.username = username;
+            claims.userId = userId;
+            claims.email = email;
             claims.roles = roles;
             return claims;
         }

--- a/src/main/java/org/ahpuh/backend/jwt/Jwt.java
+++ b/src/main/java/org/ahpuh/backend/jwt/Jwt.java
@@ -1,0 +1,92 @@
+package org.ahpuh.backend.jwt;
+
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+public class Jwt {
+
+    private final String issuer; // 토큰 발급자
+
+    private final String clientSecret; // 토큰 키 해시 값
+
+    private final int expirySeconds; // 만료시간
+
+    private final Algorithm algorithm;
+
+    private final JWTVerifier jwtVerifier; // JWT 검증자
+
+    public Jwt(final String issuer, final String clientSecret, final int expirySeconds) {
+        this.issuer = issuer;
+        this.clientSecret = clientSecret;
+        this.expirySeconds = expirySeconds;
+        this.algorithm = Algorithm.HMAC512(clientSecret);
+        this.jwtVerifier = com.auth0.jwt.JWT.require(algorithm)
+                .withIssuer(issuer)
+                .build();
+    }
+
+    public String sign(final Claims claims) {
+        final Date now = new Date();
+        final JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
+        builder.withIssuer(issuer);
+        builder.withIssuedAt(now);
+        if (expirySeconds > 0) {
+            builder.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L));
+        }
+        builder.withClaim("username", claims.username);
+        builder.withArrayClaim("roles", claims.roles);
+        return builder.sign(algorithm);
+    }
+
+    public Claims verify(final String token) throws JWTVerificationException {
+        return new Claims(jwtVerifier.verify(token));
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    static public class Claims {
+
+        String username;
+        String[] roles;
+        Date iat; // 토큰 발급 시각
+        Date exp; // 만료시간이 지난 토큰은 사용불가
+
+        Claims(final DecodedJWT decodedJWT) {
+            final Claim username = decodedJWT.getClaim("username");
+            if (!username.isNull())
+                this.username = username.asString();
+            final Claim roles = decodedJWT.getClaim("roles");
+            if (!roles.isNull()) {
+                this.roles = roles.asArray(String.class);
+            }
+            this.iat = decodedJWT.getIssuedAt();
+            this.exp = decodedJWT.getExpiresAt();
+        }
+
+        public static Claims from(final String username, final String[] roles) {
+            final Claims claims = new Claims();
+            claims.username = username;
+            claims.roles = roles;
+            return claims;
+        }
+
+        long iat() {
+            return iat != null ? iat.getTime() : -1;
+        }
+
+        long exp() {
+            return exp != null ? exp.getTime() : -1;
+        }
+
+    }
+
+}

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthentication.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthentication.java
@@ -7,13 +7,17 @@ public class JwtAuthentication {
 
     public final String token;
 
+    public final Long userId;
+
     public final String email;
 
-    public JwtAuthentication(final String token, final String email) {
+    public JwtAuthentication(final String token, final Long userId, final String email) {
         checkArgument(isNotEmpty(token), "token must be provided.");
+        checkArgument(userId != null, "userId must be provided.");
         checkArgument(isNotEmpty(email), "email must be provided.");
 
         this.token = token;
+        this.userId = userId;
         this.email = email;
     }
 

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthentication.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthentication.java
@@ -1,0 +1,20 @@
+package org.ahpuh.backend.jwt;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+public class JwtAuthentication {
+
+    public final String token;
+
+    public final String email;
+
+    public JwtAuthentication(final String token, final String email) {
+        checkArgument(isNotEmpty(token), "token must be provided.");
+        checkArgument(isNotEmpty(email), "email must be provided.");
+
+        this.token = token;
+        this.email = email;
+    }
+
+}

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationFilter.java
@@ -50,12 +50,12 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                     final Jwt.Claims claims = verify(token);
                     log.debug("Jwt parse result: {}", claims);
 
-                    final String username = claims.username;
+                    final String email = claims.email;
                     final List<GrantedAuthority> authorities = getAuthorities(claims);
 
-                    if (isNotEmpty(username) && authorities.size() > 0) {
+                    if (isNotEmpty(email) && authorities.size() > 0) {
                         final JwtAuthenticationToken authentication =
-                                new JwtAuthenticationToken(new JwtAuthentication(token, username), null, authorities);
+                                new JwtAuthenticationToken(new JwtAuthentication(token, email), null, authorities);
                         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                         SecurityContextHolder.getContext().setAuthentication(authentication);
                     }

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         /**
          * HTTP 요청 헤더에 JWT 토큰이 있는지 확인
          * JWT 토큰이 있다면, 주어진 토큰 디코딩
-         * email, roles 데이터 추출
+         * userId, email, roles 데이터 추출
          * JwtAuthenticationToken 생성해서 SecurityContext에 넣는다.
          **/
         final HttpServletRequest request = (HttpServletRequest) req;
@@ -50,12 +50,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                     final Jwt.Claims claims = verify(token);
                     log.debug("Jwt parse result: {}", claims);
 
+                    final Long userId = claims.userId;
                     final String email = claims.email;
                     final List<GrantedAuthority> authorities = getAuthorities(claims);
 
-                    if (isNotEmpty(email) && authorities.size() > 0) {
+                    if (userId != null && isNotEmpty(email) && authorities.size() > 0) {
                         final JwtAuthenticationToken authentication =
-                                new JwtAuthenticationToken(new JwtAuthentication(token, email), null, authorities);
+                                new JwtAuthenticationToken(new JwtAuthentication(token, userId, email), null, authorities);
                         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                         SecurityContextHolder.getContext().setAuthentication(authentication);
                     }

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,98 @@
+package org.ahpuh.backend.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    private final String headerKey;
+
+    private final Jwt jwt;
+
+    @Override
+    public void doFilter(final ServletRequest req, final ServletResponse res, final FilterChain chain) throws IOException, ServletException {
+        /**
+         * HTTP 요청 헤더에 JWT 토큰이 있는지 확인
+         * JWT 토큰이 있다면, 주어진 토큰 디코딩
+         * email, roles 데이터 추출
+         * JwtAuthenticationToken 생성해서 SecurityContext에 넣는다.
+         **/
+        final HttpServletRequest request = (HttpServletRequest) req;
+        final HttpServletResponse response = (HttpServletResponse) res;
+
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            final String token = getToken(request);
+            if (token != null) {
+                try {
+                    final Jwt.Claims claims = verify(token);
+                    log.debug("Jwt parse result: {}", claims);
+
+                    final String username = claims.username;
+                    final List<GrantedAuthority> authorities = getAuthorities(claims);
+
+                    if (isNotEmpty(username) && authorities.size() > 0) {
+                        final JwtAuthenticationToken authentication =
+                                new JwtAuthenticationToken(new JwtAuthentication(token, username), null, authorities);
+                        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    }
+                } catch (final Exception e) {
+                    log.warn("Jwt processing failed: {}", e.getMessage());
+                }
+            }
+        } else {
+            log.debug("SecurityContextHolder not populated with security token, as it already contained: '{}'",
+                    SecurityContextHolder.getContext().getAuthentication());
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String getToken(final HttpServletRequest request) {
+        final String token = request.getHeader(headerKey);
+        if (isNotEmpty(token)) {
+            log.debug("Jwt authorization api detected: {}", token);
+            try {
+                return URLDecoder.decode(token, "UTF-8");
+            } catch (final UnsupportedEncodingException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+        return null;
+    }
+
+    private Jwt.Claims verify(final String token) {
+        return jwt.verify(token);
+    }
+
+    private List<GrantedAuthority> getAuthorities(final Jwt.Claims claims) {
+        final String[] roles = claims.roles;
+        return roles == null || roles.length == 0
+                ? emptyList()
+                : Arrays.stream(roles).map(SimpleGrantedAuthority::new).collect(toList());
+    }
+
+}

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationProvider.java
@@ -43,7 +43,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
             final List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(user.getPermission()));
             final String token = getToken(user.getUserId(), user.getEmail(), authorities);
             final JwtAuthenticationToken authenticated =
-                    new JwtAuthenticationToken(new JwtAuthentication(token, user.getEmail()), null, authorities);
+                    new JwtAuthenticationToken(new JwtAuthentication(token, user.getUserId(), user.getEmail()), null, authorities);
             authenticated.setDetails(user);
             return authenticated;
         } catch (final IllegalArgumentException e) {

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,62 @@
+package org.ahpuh.backend.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.ahpuh.backend.user.entity.User;
+import org.ahpuh.backend.user.service.UserServiceImpl;
+import org.springframework.dao.DataAccessException;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+
+import static org.apache.commons.lang3.ClassUtils.isAssignable;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final Jwt jwt;
+
+    private final UserServiceImpl userService;
+
+    @Override
+    public boolean supports(final Class<?> authentication) {
+        return isAssignable(JwtAuthenticationToken.class, authentication);
+    }
+
+    @Override
+    public Authentication authenticate(final Authentication authentication) throws AuthenticationException {
+        final JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
+        return processUserAuthentication(
+                String.valueOf(jwtAuthentication.getPrincipal()),
+                jwtAuthentication.getCredentials()
+        );
+    }
+
+    private Authentication processUserAuthentication(final String principal, final String credentials) {
+        try {
+            final User user = userService.login(principal, credentials);
+            final List<GrantedAuthority> authorities = user.getPermission().getAuthorities();
+            final String token = getToken(user.getEmail(), authorities);
+            final JwtAuthenticationToken authenticated =
+                    new JwtAuthenticationToken(new JwtAuthentication(token, user.getEmail()), null, authorities);
+            authenticated.setDetails(user);
+            return authenticated;
+        } catch (final IllegalArgumentException e) {
+            throw new BadCredentialsException(e.getMessage());
+        } catch (final DataAccessException e) {
+            throw new AuthenticationServiceException(e.getMessage(), e);
+        }
+    }
+
+    private String getToken(final String username, final List<GrantedAuthority> authorities) {
+        final String[] roles = authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .toArray(String[]::new);
+        return jwt.sign(Jwt.Claims.from(username, roles));
+    }
+
+}

--- a/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/org/ahpuh/backend/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,54 @@
+package org.ahpuh.backend.jwt;
+
+import lombok.Getter;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+@Getter
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;
+
+    private String credentials;
+
+    public JwtAuthenticationToken(final String principal, final String credentials) {
+        super(null);
+        super.setAuthenticated(false);
+
+        this.principal = principal;
+        this.credentials = credentials;
+    }
+
+    public JwtAuthenticationToken(final Object principal, final String credentials, final Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        super.setAuthenticated(true);
+
+        this.principal = principal;
+        this.credentials = credentials;
+    }
+
+    public void setAuthenticated(final boolean isAuthenticated) throws IllegalArgumentException {
+        if (isAuthenticated) {
+            throw new IllegalArgumentException("Cannot set this token to trusted");
+        }
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        credentials = null;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("principal", principal)
+                .append("credentials", "[PROTECTED]")
+                .toString();
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #4 

> JWT 구현
> Login, 회원가입은 User 도메인 관련 PR에 넣을게요!

## 📌 구현 내용

- [X] Jwt
- [X] JwtAuthentication
- [X] JwtAuthenticationFilter
- [X] JwtAuthenticationProvider
- [X] JwtAuthenticationToken

## ✅ PR 포인트

- `Jwt`
  - 토큰 payload에 들어갈 내용을 담고 있습니다.
- `JwtAuthentication`
  - JWT 인증에 대한 데이터를 담고 있습니다.
  - token, userId, email
- `JwtAuthenticationFilter`
  - HTTP 요청 헤더에 JWT 토큰이 있는지 확인 후 있다면 토큰을 디코딩합니다.
  - (JwtAuthenticationToken을 담는) **SecurityContext**를 생성합니다.
- `JwtAuthenticationProvider`
  - JwtAuthenticationToken 타입을 처리할 수 있는 AuthenticationProvider 구현체
  - 이를 통해 UserDetailsService에 의존하지 않아도 됩니다.
- `JwtAuthenticationToken`
  - JWT 인증에 대한 토큰
  - `인증 전` -> 아이디(principal), 비밀번호(credentials)를 가지고 있습니다.
  - `인증 후` -> JwtAuthentication 객체(principal)를 가지고 있습니다.

## 토큰 디코딩
- userId, roles, email을 담고 있다.
- `iss` -> 토큰 발급자
- `exp` -> 토큰 만료 시간
- `iat` -> 토큰 발급 시각
![image](https://user-images.githubusercontent.com/60170616/144854551-eeab022f-a441-4015-ba49-c525d8bcd453.png)