### PR TITLE
User 수정, 삭제 API 수정

### DIFF
--- a/src/main/java/org/ahpuh/surf/user/controller/UserController.java
+++ b/src/main/java/org/ahpuh/surf/user/controller/UserController.java
@@ -1,9 +1,11 @@
 package org.ahpuh.surf.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ahpuh.surf.jwt.JwtAuthentication;
 import org.ahpuh.surf.user.dto.*;
 import org.ahpuh.surf.user.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -44,30 +46,19 @@ public class UserController {
 
     @PutMapping("/{userId}")
     public ResponseEntity<Long> updateUser(
-            @PathVariable final Long userId,
+            @AuthenticationPrincipal final JwtAuthentication authentication,
             @Valid @RequestBody final UserUpdateRequestDto request
     ) {
-        userService.update(userId, request);
-        return ResponseEntity.ok().body(userId);
+        userService.update(authentication.userId, request);
+        return ResponseEntity.ok().body(authentication.userId);
     }
 
     @DeleteMapping("/{userId}")
     public ResponseEntity<Void> deleteUser(
-            @PathVariable final Long userId
+            @AuthenticationPrincipal final JwtAuthentication authentication
     ) {
-        userService.delete(userId);
+        userService.delete(authentication.userId);
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * 보호받는 엔드포인트 - ROLE_USER 또는 ROLE_ADMIN 권한 필요함
-     **/
-//    @GetMapping(path = "/user/me")
-//    public UserDto me(@AuthenticationPrincipal final JwtAuthentication authentication) {
-//        return userService.findById(authentication.username)
-//                .map(user ->
-//                        new UserDto(authentication.token, authentication.username, user.getPermission().getName())
-//                )
-//                .orElseThrow(() -> new IllegalArgumentException("Could not found user for " + authentication.username));
-//    }
 }

--- a/src/main/java/org/ahpuh/surf/user/controller/UserController.java
+++ b/src/main/java/org/ahpuh/surf/user/controller/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
         return ResponseEntity.ok().body(response);
     }
 
-    @PutMapping("/{userId}")
+    @PutMapping
     public ResponseEntity<Long> updateUser(
             @AuthenticationPrincipal final JwtAuthentication authentication,
             @Valid @RequestBody final UserUpdateRequestDto request
@@ -53,7 +53,7 @@ public class UserController {
         return ResponseEntity.ok().body(authentication.userId);
     }
 
-    @DeleteMapping("/{userId}")
+    @DeleteMapping
     public ResponseEntity<Void> deleteUser(
             @AuthenticationPrincipal final JwtAuthentication authentication
     ) {

--- a/src/main/java/org/ahpuh/surf/user/entity/User.java
+++ b/src/main/java/org/ahpuh/surf/user/entity/User.java
@@ -50,7 +50,8 @@ public class User extends BaseEntity {
     private Boolean accountPublic = true;
 
     @Column(name = "permission")
-    private String permission;
+    @Builder.Default
+    private String permission = "ROLE_USER";
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -4,47 +4,47 @@ DROP TABLE IF EXISTS users CASCADE;
 
 CREATE TABLE users
 (
-    user_id           bigint auto_increment primary key,
-    user_name         varchar(20),
-    email             varchar(255) NOT NULL unique,
-    password          varchar(255) NOT NULL,
-    profile_photo_url varchar(255),
-    url               varchar(255),
-    about_me          varchar(255),
-    account_public    boolean default true,
-    permission        varchar(20),
-    created_at        timestamp,
-    updated_at        timestamp,
-    is_deleted        boolean
+    user_id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_name         VARCHAR(20),
+    email             VARCHAR(255) NOT NULL UNIQUE,
+    password          VARCHAR(255) NOT NULL,
+    profile_photo_url VARCHAR(255),
+    url               VARCHAR(255),
+    about_me          VARCHAR(255),
+    account_public    BOOLEAN     DEFAULT true,
+    permission        VARCHAR(20) DEFAULT "ROLE_USER",
+    created_at        TIMESTAMP   DEFAULT current_time,
+    updated_at        TIMESTAMP   DEFAULT current_time,
+    is_deleted        BOOLEAN     DEFAULT false
 );
 
 CREATE TABLE categories
 (
-    category_id   bigint auto_increment primary key,
-    user_id       bigint,
-    name          varchar(255) NOT NULL unique,
-    is_public     boolean default true,
-    average_score integer default 0,
-    color_code    varchar(10),
-    recent_score  integer default 0,
-    created_at    timestamp,
-    updated_at    timestamp,
-    is_deleted    boolean,
+    category_id   BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id       BIGINT       NOT NULL,
+    name          VARCHAR(255) NOT NULL UNIQUE,
+    is_public     BOOLEAN   DEFAULT true,
+    average_score INTEGER   DEFAULT 0,
+    color_code    VARCHAR(10),
+    recent_score  INTEGER   DEFAULT 0,
+    created_at    TIMESTAMP DEFAULT current_time,
+    updated_at    TIMESTAMP DEFAULT current_time,
+    is_deleted    BOOLEAN   DEFAULT false,
     CONSTRAINT fk_user_id_for_category FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );
 
 CREATE TABLE posts
 (
-    post_id       bigint auto_increment primary key,
-    user_id       bigint,
-    category_id   bigint,
-    selected_date varchar(255) NOT NULL,
-    content       varchar(500) NOT NULL,
-    score         integer      NOT NULL,
-    file_url      varchar(255),
-    created_at    timestamp,
-    updated_at    timestamp,
-    is_deleted    boolean,
+    post_id       BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id       BIGINT       NOT NULL,
+    category_id   BIGINT       NOT NULL,
+    selected_date VARCHAR(255) NOT NULL,
+    content       VARCHAR(500) NOT NULL,
+    score         INTEGER      NOT NULL,
+    file_url      VARCHAR(255),
+    created_at    TIMESTAMP DEFAULT current_time,
+    updated_at    TIMESTAMP DEFAULT current_time,
+    is_deleted    BOOLEAN   DEFAULT false,
     CONSTRAINT fk_user_id_for_post FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE RESTRICT ON UPDATE RESTRICT,
     CONSTRAINT fk_category_id_for_post FOREIGN KEY (category_id) REFERENCES categories (category_id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );

--- a/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
@@ -124,7 +124,7 @@ class UserControllerTest {
                 .accountPublic(false)
                 .build();
 
-        mockMvc.perform(put("/api/v1/users/{userId}", userId1)
+        mockMvc.perform(put("/api/v1/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                         .header("token", token))
@@ -150,7 +150,7 @@ class UserControllerTest {
                 .build();
         final String token = userController.login(req).getBody().getToken();
 
-        mockMvc.perform(delete("/api/v1/users/{userId}", userId1)
+        mockMvc.perform(delete("/api/v1/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("token", token))
                 .andExpect(status().isNoContent())

--- a/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
@@ -8,7 +8,6 @@ import org.ahpuh.surf.user.entity.User;
 import org.ahpuh.surf.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -49,21 +48,23 @@ class UserControllerTest {
     }
 
     @Test
-    @Order(1)
     @DisplayName("회원가입을 할 수 있다.")
     @Transactional
     void testJoin() throws Exception {
+        // Given
         final UserJoinRequestDto req = UserJoinRequestDto.builder()
                 .email("test1@naver.com")
                 .password("test111")
                 .build();
 
+        // When
         mockMvc.perform(post("/api/v1/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isCreated())
                 .andDo(print());
 
+        // Then
         assertAll("userJoin",
                 () -> assertThat(userRepository.findAll().size(), is(2)),
                 () -> assertThat(userRepository.findAll().get(1).getEmail(), is("test1@naver.com"))
@@ -71,15 +72,16 @@ class UserControllerTest {
     }
 
     @Test
-    @Order(2)
     @DisplayName("로그인 할 수 있다.")
     @Transactional
     void testLogin() throws Exception {
+        // Given
         final UserLoginRequestDto req = UserLoginRequestDto.builder()
                 .email("test@naver.com")
                 .password("testpw")
                 .build();
 
+        // When Then
         mockMvc.perform(post("/api/v1/users/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
@@ -88,7 +90,6 @@ class UserControllerTest {
     }
 
     @Test
-    @Order(3)
     @DisplayName("회원정보를 조회할 수 있다.")
     @Transactional
     void testFindUserInfo() throws Exception {
@@ -99,10 +100,10 @@ class UserControllerTest {
     }
 
     @Test
-    @Order(4)
     @DisplayName("회원정보를 수정할 수 있다.")
     @Transactional
     void testUpdateUser() throws Exception {
+        // Given
         final UserLoginRequestDto req = UserLoginRequestDto.builder()
                 .email("test@naver.com")
                 .password("testpw")
@@ -111,9 +112,11 @@ class UserControllerTest {
 
         final User user = userRepository.findById(userId1).get();
 
-        assertThat(user.getUserName(), is(nullValue()));
-        assertThat(user.getAboutMe(), is(nullValue()));
-        assertThat(user.getAccountPublic(), is(true));
+        assertAll("beforeUpdate",
+                () -> assertThat(user.getUserName(), is(nullValue())),
+                () -> assertThat(user.getAboutMe(), is(nullValue())),
+                () -> assertThat(user.getAccountPublic(), is(true))
+        );
 
         final UserUpdateRequestDto request = UserUpdateRequestDto.builder()
                 .userName("수정된 name")
@@ -124,6 +127,7 @@ class UserControllerTest {
                 .accountPublic(false)
                 .build();
 
+        // When
         mockMvc.perform(put("/api/v1/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
@@ -131,6 +135,7 @@ class UserControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
 
+        // Then
         assertAll("userUpdate",
                 () -> assertThat(user.getUserName(), is("수정된 name")),
                 () -> assertThat(user.getProfilePhotoUrl(), is(nullValue())),
@@ -140,22 +145,24 @@ class UserControllerTest {
     }
 
     @Test
-    @Order(5)
     @DisplayName("회원을 삭제(softDelete) 할 수 있다.")
     @Transactional
     void testDeleteUser() throws Exception {
+        // Given
         final UserLoginRequestDto req = UserLoginRequestDto.builder()
                 .email("test@naver.com")
                 .password("testpw")
                 .build();
         final String token = userController.login(req).getBody().getToken();
 
+        // When
         mockMvc.perform(delete("/api/v1/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("token", token))
                 .andExpect(status().isNoContent())
                 .andDo(print());
 
+        // Then
         assertThat(userRepository.findAll().size(), is(0));
     }
 

--- a/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
@@ -41,12 +41,11 @@ class UserControllerTest {
 
     @BeforeEach
     void setUp() {
-        final User userEntity = User.builder()
-                .email("test@naver.com")
-                .password("$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG") // testpw
-                .build();
-        userEntity.setPermission("ROLE_USER");
-        userId1 = userRepository.save(userEntity).getUserId();
+        userId1 = userRepository.save(User.builder()
+                        .email("test@naver.com")
+                        .password("$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG") // testpw
+                        .build())
+                .getUserId();
     }
 
     @Test


### PR DESCRIPTION
## 📄 Description

- close : #28 

> User 수정, 삭제 시 token에서 userId를 받아오게 수정

## 📌 구현 내용

- [x] updateUser API 수정
- [x] deleteUser API 수정

## ✅ PR 포인트

token에서 userId를 가져오는 로직으로 수정했습니다.