### PR TITLE
FOLLOW 도메인 API 구현

### DIFF
--- a/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
@@ -22,4 +22,12 @@ public class EntityExceptionHandler {
         return new IllegalArgumentException("Post with given id not found. Invalid id is " + postId);
     }
 
+    public static IllegalArgumentException FollowNotFound(final Long followId) {
+        return new IllegalArgumentException("No Follow for id : " + followId);
+    }
+
+    public static IllegalArgumentException FollowingNotFound() {
+        return new IllegalArgumentException("삭제하려는 팔로우 기록이 없습니다.");
+    }
+
 }

--- a/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
+++ b/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
@@ -1,14 +1,15 @@
 package org.ahpuh.surf.follow.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.ahpuh.surf.follow.dto.FollowUserDto;
 import org.ahpuh.surf.follow.service.FollowService;
 import org.ahpuh.surf.jwt.JwtAuthentication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -20,7 +21,7 @@ public class FollowController {
     @PostMapping("/follow")
     public ResponseEntity<Long> follow(
             @AuthenticationPrincipal final JwtAuthentication authentication,
-            @Valid @RequestBody final Long followUserId
+            @RequestBody final Long followUserId
     ) {
         final Long followId = followService.follow(authentication.userId, followUserId);
         return ResponseEntity.created(URI.create("/users/" + authentication.userId + "/following"))
@@ -35,5 +36,20 @@ public class FollowController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/users/{userId}/following")
+    public ResponseEntity<List<FollowUserDto>> findFollowingList(
+            @PathVariable final Long userId
+    ) {
+        final List<FollowUserDto> response = followService.findFollowingList(userId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/users/{userId}/follow")
+    public ResponseEntity<List<FollowUserDto>> findFollowList(
+            @PathVariable final Long userId
+    ) {
+        final List<FollowUserDto> response = followService.findFollowList(userId);
+        return ResponseEntity.ok().body(response);
+    }
 
 }

--- a/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
+++ b/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
@@ -1,0 +1,33 @@
+package org.ahpuh.surf.follow.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ahpuh.surf.follow.service.FollowService;
+import org.ahpuh.surf.jwt.JwtAuthentication;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/follow")
+    public ResponseEntity<Long> follow(
+            @AuthenticationPrincipal final JwtAuthentication authentication,
+            @Valid @RequestBody final Long followUserId
+    ) {
+        final Long followId = followService.follow(authentication.userId, followUserId);
+        return ResponseEntity.created(URI.create("/users/" + authentication.userId + "/following"))
+                .body(followId);
+    }
+
+}

--- a/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
+++ b/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
@@ -5,10 +5,7 @@ import org.ahpuh.surf.follow.service.FollowService;
 import org.ahpuh.surf.jwt.JwtAuthentication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
@@ -29,5 +26,14 @@ public class FollowController {
         return ResponseEntity.created(URI.create("/users/" + authentication.userId + "/following"))
                 .body(followId);
     }
+
+    @DeleteMapping("/follow/{followId}")
+    public ResponseEntity<Void> unfollow(
+            @PathVariable final Long followId
+    ) {
+        followService.unfollow(followId);
+        return ResponseEntity.noContent().build();
+    }
+
 
 }

--- a/src/main/java/org/ahpuh/surf/follow/converter/FollowConverter.java
+++ b/src/main/java/org/ahpuh/surf/follow/converter/FollowConverter.java
@@ -1,0 +1,19 @@
+package org.ahpuh.surf.follow.converter;
+
+import lombok.RequiredArgsConstructor;
+import org.ahpuh.surf.follow.entity.Follow;
+import org.ahpuh.surf.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FollowConverter {
+
+    public Follow toEntity(final User user, final User followedUser) {
+        return Follow.builder()
+                .user(user)
+                .followedUser(followedUser)
+                .build();
+    }
+
+}

--- a/src/main/java/org/ahpuh/surf/follow/converter/FollowConverter.java
+++ b/src/main/java/org/ahpuh/surf/follow/converter/FollowConverter.java
@@ -1,6 +1,7 @@
 package org.ahpuh.surf.follow.converter;
 
 import lombok.RequiredArgsConstructor;
+import org.ahpuh.surf.follow.dto.FollowUserDto;
 import org.ahpuh.surf.follow.entity.Follow;
 import org.ahpuh.surf.user.entity.User;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,14 @@ public class FollowConverter {
         return Follow.builder()
                 .user(user)
                 .followedUser(followedUser)
+                .build();
+    }
+
+    public FollowUserDto toFollowUserDto(final User user) {
+        return FollowUserDto.builder()
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .profilePhotoUrl(user.getProfilePhotoUrl())
                 .build();
     }
 

--- a/src/main/java/org/ahpuh/surf/follow/dto/FollowUserDto.java
+++ b/src/main/java/org/ahpuh/surf/follow/dto/FollowUserDto.java
@@ -1,0 +1,17 @@
+package org.ahpuh.surf.follow.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Builder
+public class FollowUserDto {
+
+    private Long userId;
+
+    private String userName;
+
+    private String profilePhotoUrl;
+
+}

--- a/src/main/java/org/ahpuh/surf/follow/entity/Follow.java
+++ b/src/main/java/org/ahpuh/surf/follow/entity/Follow.java
@@ -1,0 +1,36 @@
+package org.ahpuh.surf.follow.entity;
+
+import lombok.*;
+import org.ahpuh.surf.user.entity.User;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "follow")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Follow {
+
+    @Id
+    @Column(name = "follow_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long followId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", referencedColumnName = "user_id")
+    private User followedUser;
+
+    @Builder
+    public Follow(final User user, final User followedUser) {
+        this.user = user;
+        this.followedUser = followedUser;
+        user.addFollowedUser(this);
+        followedUser.addFollowingUser(this);
+    }
+
+}

--- a/src/main/java/org/ahpuh/surf/follow/repository/FollowRepository.java
+++ b/src/main/java/org/ahpuh/surf/follow/repository/FollowRepository.java
@@ -1,0 +1,7 @@
+package org.ahpuh.surf.follow.repository;
+
+import org.ahpuh.surf.follow.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+}

--- a/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
+++ b/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
@@ -4,4 +4,6 @@ public interface FollowService {
 
     Long follow(Long userId, Long followUserId);
 
+    void unfollow(Long followId);
+
 }

--- a/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
+++ b/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
@@ -1,9 +1,17 @@
 package org.ahpuh.surf.follow.service;
 
+import org.ahpuh.surf.follow.dto.FollowUserDto;
+
+import java.util.List;
+
 public interface FollowService {
 
     Long follow(Long userId, Long followUserId);
 
     void unfollow(Long followId);
+
+    List<FollowUserDto> findFollowingList(Long userId);
+
+    List<FollowUserDto> findFollowList(Long userId);
 
 }

--- a/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
+++ b/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
@@ -1,0 +1,7 @@
+package org.ahpuh.surf.follow.service;
+
+public interface FollowService {
+
+    Long follow(Long userId, Long followUserId);
+
+}

--- a/src/main/java/org/ahpuh/surf/follow/service/FollowServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/follow/service/FollowServiceImpl.java
@@ -2,15 +2,18 @@ package org.ahpuh.surf.follow.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.follow.converter.FollowConverter;
+import org.ahpuh.surf.follow.entity.Follow;
 import org.ahpuh.surf.follow.repository.FollowRepository;
 import org.ahpuh.surf.user.entity.User;
 import org.ahpuh.surf.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import static org.ahpuh.surf.common.exception.EntityExceptionHandler.UserNotFound;
+import static org.ahpuh.surf.common.exception.EntityExceptionHandler.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FollowServiceImpl implements FollowService {
 
     private final FollowRepository followRepository;
@@ -20,6 +23,7 @@ public class FollowServiceImpl implements FollowService {
     private final UserRepository userRepository;
 
     @Override
+    @Transactional
     public Long follow(final Long userId, final Long followUserId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFound(userId));
@@ -29,4 +33,23 @@ public class FollowServiceImpl implements FollowService {
         return followRepository.save(followConverter.toEntity(user, followedUser))
                 .getFollowId();
     }
+
+    @Override
+    @Transactional
+    public void unfollow(final Long followId) {
+        final Follow followEntity = followRepository.findById(followId)
+                .orElseThrow(() -> FollowNotFound(followId));
+        final User user = followEntity.getUser();
+        final User followedUser = followEntity.getFollowedUser();
+
+        if (!user.getFollowedUsers().remove(followEntity)) {
+            throw FollowingNotFound();
+        }
+        if (!followedUser.getFollowingUsers().remove(followEntity)) {
+            throw FollowingNotFound();
+        }
+
+        followRepository.deleteById(followId);
+    }
+
 }

--- a/src/main/java/org/ahpuh/surf/follow/service/FollowServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/follow/service/FollowServiceImpl.java
@@ -1,0 +1,32 @@
+package org.ahpuh.surf.follow.service;
+
+import lombok.RequiredArgsConstructor;
+import org.ahpuh.surf.follow.converter.FollowConverter;
+import org.ahpuh.surf.follow.repository.FollowRepository;
+import org.ahpuh.surf.user.entity.User;
+import org.ahpuh.surf.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import static org.ahpuh.surf.common.exception.EntityExceptionHandler.UserNotFound;
+
+@Service
+@RequiredArgsConstructor
+public class FollowServiceImpl implements FollowService {
+
+    private final FollowRepository followRepository;
+
+    private final FollowConverter followConverter;
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Long follow(final Long userId, final Long followUserId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> UserNotFound(userId));
+        final User followedUser = userRepository.findById(followUserId)
+                .orElseThrow(() -> UserNotFound(followUserId));
+
+        return followRepository.save(followConverter.toEntity(user, followedUser))
+                .getFollowId();
+    }
+}

--- a/src/main/java/org/ahpuh/surf/follow/service/FollowServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/follow/service/FollowServiceImpl.java
@@ -2,12 +2,15 @@ package org.ahpuh.surf.follow.service;
 
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.follow.converter.FollowConverter;
+import org.ahpuh.surf.follow.dto.FollowUserDto;
 import org.ahpuh.surf.follow.entity.Follow;
 import org.ahpuh.surf.follow.repository.FollowRepository;
 import org.ahpuh.surf.user.entity.User;
 import org.ahpuh.surf.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.ahpuh.surf.common.exception.EntityExceptionHandler.*;
 
@@ -50,6 +53,28 @@ public class FollowServiceImpl implements FollowService {
         }
 
         followRepository.deleteById(followId);
+    }
+
+    @Override
+    public List<FollowUserDto> findFollowingList(final Long userId) {
+        final User userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> UserNotFound(userId));
+        return userEntity.getFollowingUsers()
+                .stream()
+                .map(Follow::getUser)
+                .map(followConverter::toFollowUserDto)
+                .toList();
+    }
+
+    @Override
+    public List<FollowUserDto> findFollowList(final Long userId) {
+        final User userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> UserNotFound(userId));
+        return userEntity.getFollowedUsers()
+                .stream()
+                .map(Follow::getFollowedUser)
+                .map(followConverter::toFollowUserDto)
+                .toList();
     }
 
 }

--- a/src/main/java/org/ahpuh/surf/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/org/ahpuh/surf/jwt/JwtAuthenticationProvider.java
@@ -40,7 +40,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     private Authentication processUserAuthentication(final String principal, final String credentials) {
         try {
             final User user = userService.login(principal, credentials);
-            final List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(user.getPermission()));
+            final List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(user.getPermission().getRole()));
             final String token = getToken(user.getUserId(), user.getEmail(), authorities);
             final JwtAuthenticationToken authenticated =
                     new JwtAuthenticationToken(new JwtAuthentication(token, user.getUserId(), user.getEmail()), null, authorities);

--- a/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
+++ b/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
@@ -30,8 +30,8 @@ public class UserConverter {
                 .profilePhotoUrl(userEntity.getProfilePhotoUrl())
                 .aboutMe(userEntity.getAboutMe())
                 .url(userEntity.getUrl())
-//                .followerCount(userEntity.)
-//                .followingCount(userEntity.)
+                .followerCount(userEntity.getFollowingUsers().size())
+                .followingCount(userEntity.getFollowedUsers().size())
                 .build();
     }
 

--- a/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
+++ b/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
@@ -18,7 +18,6 @@ public class UserConverter {
                 .email(dto.getEmail())
                 .password(bCryptEncoder.encode(dto.getPassword()))
                 .build();
-        user.setPermission("ROLE_USER");
         return user;
     }
 

--- a/src/main/java/org/ahpuh/surf/user/entity/Permission.java
+++ b/src/main/java/org/ahpuh/surf/user/entity/Permission.java
@@ -1,0 +1,19 @@
+package org.ahpuh.surf.user.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum Permission {
+    ROLE_USER("USER"),
+    ROLE_ADMIN("ADMIN");
+
+    @JsonValue
+    private final String role;
+
+    Permission(final String role) {
+        this.role = role;
+    }
+}

--- a/src/main/java/org/ahpuh/surf/user/entity/User.java
+++ b/src/main/java/org/ahpuh/surf/user/entity/User.java
@@ -51,7 +51,8 @@ public class User extends BaseEntity {
     private Boolean accountPublic = true;
 
     @Column(name = "permission")
-    private String permission;
+    @Builder.Default
+    private String permission = "ROLE_USER";
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default

--- a/src/main/java/org/ahpuh/surf/user/entity/User.java
+++ b/src/main/java/org/ahpuh/surf/user/entity/User.java
@@ -51,8 +51,9 @@ public class User extends BaseEntity {
     private Boolean accountPublic = true;
 
     @Column(name = "permission")
+    @Enumerated(value = EnumType.STRING)
     @Builder.Default
-    private String permission = "ROLE_USER";
+    private Permission permission = Permission.ROLE_USER;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -81,7 +82,7 @@ public class User extends BaseEntity {
             throw new IllegalArgumentException("Bad credential");
     }
 
-    public void setPermission(final String permission) {
+    public void setPermission(final Permission permission) {
         this.permission = permission;
     }
 

--- a/src/main/java/org/ahpuh/surf/user/entity/User.java
+++ b/src/main/java/org/ahpuh/surf/user/entity/User.java
@@ -4,6 +4,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.ahpuh.surf.category.entity.Category;
 import org.ahpuh.surf.common.entity.BaseEntity;
+import org.ahpuh.surf.follow.entity.Follow;
 import org.ahpuh.surf.post.entity.Post;
 import org.ahpuh.surf.user.dto.UserUpdateRequestDto;
 import org.hibernate.annotations.Where;
@@ -60,6 +61,14 @@ public class User extends BaseEntity {
     @Builder.Default
     private List<Post> posts = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Follow> followedUsers = new ArrayList<>(); // 내가 팔로우한 (팔로우 당한)
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Follow> followingUsers = new ArrayList<>(); // 나를 팔로잉한
+
     @Builder
     public User(final String email, final String password) {
         this.email = email;
@@ -90,6 +99,14 @@ public class User extends BaseEntity {
 
     public void addPost(final Post post) {
         posts.add(post);
+    }
+
+    public void addFollowedUser(final Follow followedUser) {
+        followedUsers.add(followedUser);
+    }
+
+    public void addFollowingUser(final Follow followingUser) {
+        followingUsers.add(followingUser);
     }
 
 }

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS follow CASCADE;
 DROP TABLE IF EXISTS posts CASCADE;
 DROP TABLE IF EXISTS categories CASCADE;
 DROP TABLE IF EXISTS users CASCADE;
@@ -47,4 +48,13 @@ CREATE TABLE posts
     is_deleted    boolean,
     CONSTRAINT fk_user_id_for_post FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE RESTRICT ON UPDATE RESTRICT,
     CONSTRAINT fk_category_id_for_post FOREIGN KEY (category_id) REFERENCES categories (category_id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+CREATE TABLE follow
+(
+    follow_id    BIGINT AUTO_INCREMENT primary key,
+    user_id      BIGINT,
+    following_id BIGINT,
+    CONSTRAINT fk_user_id_for_follow FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT fk_following_id_for_follow FOREIGN KEY (following_id) REFERENCES users (user_id) ON DELETE RESTRICT ON UPDATE RESTRICT
 );

--- a/src/test/java/org/ahpuh/surf/follow/controller/FollowControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/follow/controller/FollowControllerTest.java
@@ -1,0 +1,103 @@
+package org.ahpuh.surf.follow.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ahpuh.surf.user.controller.UserController;
+import org.ahpuh.surf.user.dto.UserLoginRequestDto;
+import org.ahpuh.surf.user.entity.User;
+import org.ahpuh.surf.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+class FollowControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private FollowController followController;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserController userController;
+
+    private Long userId1;
+    private Long userId2;
+    private Long userId3;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        userId1 = userRepository.save(User.builder()
+                        .email("user1@naver.com")
+                        .password("$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG") // testpw
+                        .build())
+                .getUserId();
+        userId2 = userRepository.save(User.builder()
+                        .email("user2@naver.com")
+                        .password("$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG") // testpw
+                        .build())
+                .getUserId();
+        userId3 = userRepository.save(User.builder()
+                        .email("user3@naver.com")
+                        .password("$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG") // testpw
+                        .build())
+                .getUserId();
+
+        final UserLoginRequestDto userJoinRequest = UserLoginRequestDto.builder()
+                .email("user1@naver.com")
+                .password("testpw")
+                .build();
+        token = userController.login(userJoinRequest)
+                .getBody()
+                .getToken();
+    }
+
+    @Test
+    @DisplayName("팔로우를 할 수 있다.")
+    @Transactional
+    void testFollow() throws Exception {
+        final User user1 = userRepository.getById(userId1);
+        final User user2 = userRepository.getById(userId2);
+
+        assertAll("beforeFollow",
+                () -> assertThat(user1.getEmail(), is("user1@naver.com")),
+                () -> assertThat(user1.getFollowedUsers().size(), is(0)),
+                () -> assertThat(user2.getEmail(), is("user2@naver.com")),
+                () -> assertThat(user2.getFollowingUsers().size(), is(0))
+        );
+
+        mockMvc.perform(post("/api/v1/follow")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userId2))
+                        .header("token", token))
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+        assertAll("afterFollow",
+                () -> assertThat(user1.getFollowedUsers().size(), is(1)),
+                () -> assertThat(user1.getFollowedUsers().get(0).getUser().getUserId(), is(userId1)),
+                () -> assertThat(user1.getFollowedUsers().get(0).getFollowedUser().getUserId(), is(userId2)),
+                () -> assertThat(user2.getFollowingUsers().size(), is(1)),
+                () -> assertThat(user2.getFollowingUsers().get(0).getUser().getUserId(), is(userId1)),
+                () -> assertThat(user2.getFollowingUsers().get(0).getFollowedUser().getUserId(), is(userId2))
+        );
+    }
+
+}

--- a/src/test/java/org/ahpuh/surf/follow/controller/FollowControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/follow/controller/FollowControllerTest.java
@@ -1,12 +1,14 @@
 package org.ahpuh.surf.follow.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ahpuh.surf.follow.repository.FollowRepository;
 import org.ahpuh.surf.user.controller.UserController;
 import org.ahpuh.surf.user.dto.UserLoginRequestDto;
 import org.ahpuh.surf.user.entity.User;
 import org.ahpuh.surf.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,6 +33,8 @@ class FollowControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
+    @Autowired
+    private FollowRepository followRepository;
     @Autowired
     private FollowController followController;
     @Autowired
@@ -70,9 +75,11 @@ class FollowControllerTest {
     }
 
     @Test
+    @Order(1)
     @DisplayName("팔로우를 할 수 있다.")
     @Transactional
     void testFollow() throws Exception {
+        // Given
         final User user1 = userRepository.getById(userId1);
         final User user2 = userRepository.getById(userId2);
 
@@ -83,6 +90,7 @@ class FollowControllerTest {
                 () -> assertThat(user2.getFollowingUsers().size(), is(0))
         );
 
+        // When
         mockMvc.perform(post("/api/v1/follow")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(userId2))
@@ -90,6 +98,7 @@ class FollowControllerTest {
                 .andExpect(status().isCreated())
                 .andDo(print());
 
+        // Then
         assertAll("afterFollow",
                 () -> assertThat(user1.getFollowedUsers().size(), is(1)),
                 () -> assertThat(user1.getFollowedUsers().get(0).getUser().getUserId(), is(userId1)),
@@ -97,6 +106,41 @@ class FollowControllerTest {
                 () -> assertThat(user2.getFollowingUsers().size(), is(1)),
                 () -> assertThat(user2.getFollowingUsers().get(0).getUser().getUserId(), is(userId1)),
                 () -> assertThat(user2.getFollowingUsers().get(0).getFollowedUser().getUserId(), is(userId2))
+        );
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("언팔로우를 할 수 있다.")
+    @Transactional
+    void testUnfollow() throws Exception {
+        // Given
+        mockMvc.perform(post("/api/v1/follow")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userId2))
+                        .header("token", token))
+                .andExpect(status().isCreated())
+                .andDo(print());
+
+        assertAll("beforeFollow",
+                () -> assertThat(userRepository.getById(userId1).getFollowedUsers().size(), is(1)),
+                () -> assertThat(userRepository.getById(userId2).getFollowingUsers().size(), is(1)),
+                () -> assertThat(followRepository.findAll().size(), is(1))
+        );
+        final Long followid = followRepository.findAll().get(0).getFollowId();
+
+        // When
+        mockMvc.perform(delete("/api/v1/follow/{followId}", followid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("token", token))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+
+        // Then
+        assertAll("afterFollow",
+                () -> assertThat(userRepository.getById(userId1).getFollowedUsers().size(), is(0)),
+                () -> assertThat(userRepository.getById(userId2).getFollowingUsers().size(), is(0)),
+                () -> assertThat(followRepository.findAll().size(), is(0))
         );
     }
 

--- a/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.ahpuh.surf.user.dto.UserJoinRequestDto;
 import org.ahpuh.surf.user.dto.UserLoginRequestDto;
 import org.ahpuh.surf.user.dto.UserUpdateRequestDto;
+import org.ahpuh.surf.user.entity.Permission;
 import org.ahpuh.surf.user.entity.User;
 import org.ahpuh.surf.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,12 +41,11 @@ class UserControllerTest {
 
     @BeforeEach
     void setUp() {
-        final User userEntity = User.builder()
-                .email("test@naver.com")
-                .password("$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG") // testpw
-                .build();
-        userEntity.setPermission("ROLE_USER");
-        userId1 = userRepository.save(userEntity).getUserId();
+        userId1 = userRepository.save(User.builder()
+                        .email("test@naver.com")
+                        .password("$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG") // testpw
+                        .build())
+                .getUserId();
     }
 
     @Test


### PR DESCRIPTION
## 📄 Description

- close : #27 

> FOLLOW 도메인 API 구현

## 📌 구현 내용

- [X] Follow
- [X] UnFollow
- [X] 특정 User를 팔로우 한 사람들의 목록 전체 조회
- [X] 특정 User가 팔로우 한 사람들의 목록 전체 조회

## ✅ PR 포인트
- User 엔티티에 '팔로우 한 유저 목록'과 '팔로잉 한 유저 목록'을 `@OneToMany`로 연관관계 설정하고, 객체 그래프 탐색하려고
  List\<Follow>로 받았고, 리스트에 담겨있는 Follow에서 '팔로우 한 유저'와 '팔로잉 한 유저'를 가져오는 로직으로 설정했습니다.  
  List\<User>로 받으면 더 간편해질텐데 안되겠죠..?
- follow 테이블까지 sql schema 파일에 추가해놨습니다.
- User의 팔로워, 팔로잉 수도 볼 수 있게 수정했습니다.