### PR TITLE
Post 일년치 게시글 점수 조회 구현

### DIFF
--- a/src/main/java/org/ahpuh/surf/post/controller/PostController.java
+++ b/src/main/java/org/ahpuh/surf/post/controller/PostController.java
@@ -4,13 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.category.dto.CategorySimpleDto;
 import org.ahpuh.surf.common.response.CursorResult;
 import org.ahpuh.surf.jwt.JwtAuthentication;
-import org.ahpuh.surf.post.dto.FollowingPostDto;
-import org.ahpuh.surf.post.dto.PostCountDto;
-import org.ahpuh.surf.post.dto.PostDto;
-import org.ahpuh.surf.post.dto.PostResponseDto;
-import org.springframework.data.domain.PageRequest;
-import org.ahpuh.surf.post.dto.PostRequestDto;
+import org.ahpuh.surf.post.dto.*;
 import org.ahpuh.surf.post.service.PostService;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -61,7 +57,7 @@ public class PostController {
                 .body(responses);
     }
 
-    @GetMapping("/posts/score") // 사용 X
+    @GetMapping("/posts/score")
     public ResponseEntity<List<CategorySimpleDto>> getScores(@RequestParam final Long userId) {
         final List<CategorySimpleDto> responses = postService.getScoresWithCategoryByUserId(userId);
         return ResponseEntity.ok()

--- a/src/main/java/org/ahpuh/surf/post/dto/PostScoreCategoryDto.java
+++ b/src/main/java/org/ahpuh/surf/post/dto/PostScoreCategoryDto.java
@@ -1,0 +1,28 @@
+package org.ahpuh.surf.post.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.ahpuh.surf.category.entity.Category;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostScoreCategoryDto {
+
+    private Category category;
+    private LocalDate selectedDate;
+    private int score;
+
+    @QueryProjection
+    public PostScoreCategoryDto(final Category category, final LocalDate selectedDate, final int score) {
+        this.category = category;
+        this.selectedDate = selectedDate;
+        this.score = score;
+    }
+
+}

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryImpl.java
@@ -1,16 +1,8 @@
 package org.ahpuh.surf.post.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.ahpuh.surf.post.dto.FollowingPostDto;
-import org.ahpuh.surf.post.dto.QFollowingPostDto;
-
-import javax.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import org.ahpuh.surf.category.dto.CategorySimpleDto;
-import org.ahpuh.surf.post.dto.FollowingPostDto;
-import org.ahpuh.surf.post.dto.PostCountDto;
-import org.ahpuh.surf.post.dto.QFollowingPostDto;
-import org.ahpuh.surf.post.dto.QPostCountDto;
+import org.ahpuh.surf.post.dto.*;
 import org.ahpuh.surf.user.entity.User;
 
 import java.time.LocalDate;
@@ -62,27 +54,18 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
     }
 
     @Override
-    public List<CategorySimpleDto> findAllScoreWithCategoryByUser(final User user) {
-        // TODO: query 수정
-        /*return queryFactory
-                .select(new QCategorySimpleDto(
-                        post.category.categoryId.as("categoryId"),
-                        post.category.name.as("categoryName"),
-                        post.category.colorCode.as("colorCode"),
-                        ExpressionUtils.as(
-                                JPAExpressions
-                                        .select(new QPostScoreDto(post.selectedDate, post.score))
-                                        .from(post)
-                                        .where(post.category.eq()),
-                                "posts")
+    public List<PostScoreCategoryDto> findAllScoreWithCategoryByUser(final User user) {
+        return queryFactory
+                .select(new QPostScoreCategoryDto(
+                        post.category.as("category"),
+                        post.selectedDate.as("selectedDate"),
+                        post.score.as("score")
                 ))
                 .from(post)
-                .where(post.selectedDate.after(LocalDate.now().minusYears(1)),  // 현재부터 1년 전
-                        post.user.eq(user))
-                .groupBy(post.category)
+                .where(post.user.eq(user))
+                .orderBy(post.category.categoryId.asc(), post.selectedDate.asc())
                 .fetch()
-                ;*/
-        return null;
+                ;
     }
 
 }

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryQuerydsl.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryQuerydsl.java
@@ -1,8 +1,8 @@
 package org.ahpuh.surf.post.repository;
 
-import org.ahpuh.surf.category.dto.CategorySimpleDto;
 import org.ahpuh.surf.post.dto.FollowingPostDto;
 import org.ahpuh.surf.post.dto.PostCountDto;
+import org.ahpuh.surf.post.dto.PostScoreCategoryDto;
 import org.ahpuh.surf.user.entity.User;
 
 import java.util.List;
@@ -13,6 +13,6 @@ public interface PostRepositoryQuerydsl {
 
     List<PostCountDto> findAllDateAndCountBetween(int year, User user);
 
-    List<CategorySimpleDto> findAllScoreWithCategoryByUser(User user);
+    List<PostScoreCategoryDto> findAllScoreWithCategoryByUser(User user);
 
 }

--- a/src/main/java/org/ahpuh/surf/post/service/PostService.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostService.java
@@ -1,15 +1,11 @@
 package org.ahpuh.surf.post.service;
 
 import org.ahpuh.surf.category.dto.CategorySimpleDto;
-import org.ahpuh.surf.post.dto.FollowingPostDto;
-import org.ahpuh.surf.post.dto.PostCountDto;
 import org.ahpuh.surf.common.response.CursorResult;
-import org.ahpuh.surf.post.dto.PostDto;
-import org.ahpuh.surf.post.dto.PostRequestDto;
+import org.ahpuh.surf.post.dto.*;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import org.ahpuh.surf.post.dto.PostResponseDto;
-import org.springframework.data.domain.Pageable;
 
 
 public interface PostService {

--- a/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
@@ -5,14 +5,10 @@ import org.ahpuh.surf.category.dto.CategorySimpleDto;
 import org.ahpuh.surf.category.entity.Category;
 import org.ahpuh.surf.category.repository.CategoryRepository;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
-import org.ahpuh.surf.like.repository.LikeRepository;
 import org.ahpuh.surf.common.response.CursorResult;
+import org.ahpuh.surf.like.repository.LikeRepository;
 import org.ahpuh.surf.post.converter.PostConverter;
-import org.ahpuh.surf.post.dto.FollowingPostDto;
-import org.ahpuh.surf.post.dto.PostCountDto;
-import org.ahpuh.surf.post.dto.PostDto;
-import org.ahpuh.surf.post.dto.PostRequestDto;
-import org.ahpuh.surf.post.dto.PostResponseDto;
+import org.ahpuh.surf.post.dto.*;
 import org.ahpuh.surf.post.entity.Post;
 import org.ahpuh.surf.post.repository.PostRepository;
 import org.ahpuh.surf.user.entity.User;
@@ -33,6 +29,7 @@ public class PostServiceImpl implements PostService {
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
     private final LikeRepository likeRepository;
+    private final PostConverter postConverter;
 
     @Transactional
     public Long create(final Long userId, final PostRequestDto request) {
@@ -88,7 +85,9 @@ public class PostServiceImpl implements PostService {
 
     public List<CategorySimpleDto> getScoresWithCategoryByUserId(final Long userId) {
         final User user = getUserById(userId);
-        return postRepository.findAllScoreWithCategoryByUser(user);
+        final List<PostScoreCategoryDto> posts = postRepository.findAllScoreWithCategoryByUser(user);
+        final List<Category> categories = categoryRepository.findAll();
+        return postConverter.sortPostScoresByCategory(posts, categories);
     }
 
     private User getUserById(final Long userId) {

--- a/src/test/java/org/ahpuh/surf/post/PostTest.java
+++ b/src/test/java/org/ahpuh/surf/post/PostTest.java
@@ -1,0 +1,148 @@
+package org.ahpuh.surf.post;
+
+import org.ahpuh.surf.category.dto.CategorySimpleDto;
+import org.ahpuh.surf.category.entity.Category;
+import org.ahpuh.surf.category.repository.CategoryRepository;
+import org.ahpuh.surf.post.dto.PostCountDto;
+import org.ahpuh.surf.post.entity.Post;
+import org.ahpuh.surf.post.repository.PostRepository;
+import org.ahpuh.surf.post.service.PostService;
+import org.ahpuh.surf.user.controller.UserController;
+import org.ahpuh.surf.user.dto.UserJoinRequestDto;
+import org.ahpuh.surf.user.entity.User;
+import org.ahpuh.surf.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PostTest {
+
+    private Long userId2;
+    private Category category2;
+    private Category category3;
+    private int year;
+
+    @Autowired
+    private UserController userController;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private PostService postService;
+
+    @BeforeEach
+    void setUp() {
+        year = 2021;
+
+        final Long userId1 = saveUser("test1@naver.com", "test1");
+        userId2 = saveUser("test2@naver.com", "test2");
+
+        final User user1 = userRepository.getById(userId1);
+        final User user2 = userRepository.getById(userId2);
+
+        final Category category1 = saveCategory(user1, "category 1");
+        category2 = saveCategory(user2, "category 2");
+        category3 = saveCategory(user2, "category 3");
+
+        // post 생성
+        savePost(user1, category1, LocalDate.now(), "content111", 0);
+
+        savePost(user2, category3, LocalDate.of(2020, 12, 12), "content5", 90);
+        savePost(user2, category3, LocalDate.of(year, 12, 31), "content6", 50);
+        savePost(user2, category3, LocalDate.of(year, 1, 1), "content7", 100);
+
+        savePost(user2, category2, LocalDate.of(year, 12, 10), "content1", 80);
+        savePost(user2, category2, LocalDate.of(2022, 12, 23), "content2", 90);
+        savePost(user2, category2, LocalDate.of(year, 12, 31), "content3", 50);
+        savePost(user2, category2, LocalDate.of(year, 12, 4), "content4", 100);
+    }
+
+    @Test
+    @DisplayName("해당년도 게시글 개수 정보 조회")
+    @Transactional
+    void getCountsPerDayWithYear() {
+        // when
+        final List<PostCountDto> response = postService.getCountsPerDayWithYear(year, userId2);
+
+        // then
+        assertAll(
+                () -> assertThat(response.size()).isEqualTo(4),
+                () -> assertThat(response.get(0).getDate()).isEqualTo(LocalDate.of(year, 1, 1)),
+                () -> assertThat(response.get(0).getCount()).isEqualTo(1),
+                () -> assertThat(response.get(2).getDate()).isEqualTo(LocalDate.of(year, 12, 10)),
+                () -> assertThat(response.get(2).getCount()).isEqualTo(1),
+                () -> assertThat(response.get(3).getDate()).isEqualTo(LocalDate.of(year, 12, 31)),
+                () -> assertThat(response.get(3).getCount()).isEqualTo(2)
+        );
+    }
+
+    @Test
+    @DisplayName("일년치 게시글 점수 조회")
+    @Transactional
+    void getScoresWithCategoryByUserId() {
+        // when
+        final List<CategorySimpleDto> response = postService.getScoresWithCategoryByUserId(userId2);
+
+        final CategorySimpleDto categorySimpleDto1 = response.get(0);
+        final CategorySimpleDto categorySimpleDto2 = response.get(1);
+
+        // then
+        assertAll(
+                () -> assertThat(response.size()).isEqualTo(2),
+
+                () -> assertThat(categorySimpleDto1.getCategoryId()).isEqualTo(category2.getCategoryId()),
+                () -> assertThat(categorySimpleDto1.getPostScores().size()).isEqualTo(4),
+                () -> assertThat(categorySimpleDto1.getPostScores().get(0).getScore()).isEqualTo(100),
+                () -> assertThat(categorySimpleDto1.getPostScores().get(1).getScore()).isEqualTo(80),
+                () -> assertThat(categorySimpleDto1.getPostScores().get(2).getScore()).isEqualTo(50),
+                () -> assertThat(categorySimpleDto1.getPostScores().get(3).getScore()).isEqualTo(90),
+
+                () -> assertThat(categorySimpleDto2.getCategoryId()).isEqualTo(category3.getCategoryId()),
+                () -> assertThat(categorySimpleDto2.getPostScores().size()).isEqualTo(3),
+                () -> assertThat(categorySimpleDto2.getPostScores().get(0).getScore()).isEqualTo(90),
+                () -> assertThat(categorySimpleDto2.getPostScores().get(1).getScore()).isEqualTo(100),
+                () -> assertThat(categorySimpleDto2.getPostScores().get(2).getScore()).isEqualTo(50)
+        );
+    }
+
+    private Long saveUser(final String email, final String pw) {
+        return userController.join(UserJoinRequestDto.builder()
+                        .email(email)
+                        .password(pw)
+                        .userName("name")
+                        .build())
+                .getBody();
+    }
+
+    private Category saveCategory(final User user, final String categoryName) {
+        return categoryRepository.save(Category.builder()
+                .user(user)
+                .name(categoryName)
+                .build());
+    }
+
+    private void savePost(final User user, final Category category, final LocalDate selectedDate, final String content,
+                          final int score) {
+        postRepository.save(Post.builder()
+                .user(user)
+                .category(category)
+                .selectedDate(selectedDate)
+                .content(content)
+                .score(score)
+                .build());
+    }
+
+}


### PR DESCRIPTION
## 📄 Description

- close : #41 

## 📌 구현 내용

- [x] 일년치 게시글 점수 조회 구현
- [x] 일년치 게시글 점수 조회 테스트
- [x] 해당년도 게시글 개수 정보 조회 테스트

## ✅ PR 포인트
list<dto>안에 list<dto>를 비즈니스 로직으로 처리하는 부분 `PostConverter.sortPostScoresByCategory()`에서 구현하였습니다. 로직이 너무 복잡한것 같은데 한 번 다른 의견이 있으시다면 알려주시면 좋겠습니다!