### PR TITLE
API 테스트 및 수정

### DIFF
--- a/src/main/java/org/ahpuh/surf/category/converter/CategoryConverter.java
+++ b/src/main/java/org/ahpuh/surf/category/converter/CategoryConverter.java
@@ -24,7 +24,6 @@ public class CategoryConverter {
                 .name(category.getName())
                 .isPublic(category.getIsPublic())
                 .colorCode(category.getColorCode())
-                .recentScore(category.getRecentScore())
                 .build();
     }
 

--- a/src/main/java/org/ahpuh/surf/category/converter/CategoryConverter.java
+++ b/src/main/java/org/ahpuh/surf/category/converter/CategoryConverter.java
@@ -27,11 +27,11 @@ public class CategoryConverter {
                 .build();
     }
 
-    public CategoryDetailResponseDto toCategoryDetailResponseDto(final Category category) {
+    public CategoryDetailResponseDto toCategoryDetailResponseDto(final Category category, int averageScore) {
         return CategoryDetailResponseDto.builder()
                 .categoryId(category.getCategoryId())
                 .name(category.getName())
-                .averageScore(category.getAverageScore())
+                .averageScore(averageScore)
                 .isPublic(category.getIsPublic())
                 .colorCode(category.getColorCode())
                 .postCount(category.getPostCount())

--- a/src/main/java/org/ahpuh/surf/category/dto/CategoryResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/category/dto/CategoryResponseDto.java
@@ -16,6 +16,4 @@ public class CategoryResponseDto {
 
     private String colorCode;
 
-    private int recentScore;
-
 }

--- a/src/main/java/org/ahpuh/surf/category/entity/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/entity/Category.java
@@ -38,14 +38,6 @@ public class Category extends BaseEntity {
     @Column(name = "color_code")
     private String colorCode;
 
-    @Column(name = "average_score")
-    @Builder.Default
-    private int averageScore = 0;
-
-    @Column(name = "recent_score")
-    @Builder.Default
-    private int recentScore = 0;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "user_id")
     private User user;
@@ -68,18 +60,12 @@ public class Category extends BaseEntity {
 
     public void addPost(final Post post) {
         posts.add(post);
-        this.recentScore = post.getScore();
-        this.averageScore = updateAverageScore(post.getScore()) / (++postCount);
     }
 
     public void update(final String name, final boolean isPublic, final String colorCode) {
         this.name = name;
         this.isPublic = isPublic;
         this.colorCode = colorCode;
-    }
-
-    public int updateAverageScore(final int score) {
-        return this.averageScore * this.postCount + score;
     }
 
 }

--- a/src/main/java/org/ahpuh/surf/category/entity/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/entity/Category.java
@@ -46,7 +46,7 @@ public class Category extends BaseEntity {
     @Builder.Default
     private List<Post> posts = new ArrayList<>();
 
-    @Formula("(select count(1) from posts where is_deleted = false)")
+    @Formula("(select count(1) from posts where posts.category_id = category_id AND is_deleted = false)")
     @Builder.Default
     private int postCount = 0;
 

--- a/src/main/java/org/ahpuh/surf/category/entity/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/entity/Category.java
@@ -46,9 +46,8 @@ public class Category extends BaseEntity {
     @Builder.Default
     private List<Post> posts = new ArrayList<>();
 
-    @Formula("(select count(1) from posts where posts.category_id = category_id AND is_deleted = false)")
-    @Builder.Default
-    private int postCount = 0;
+    @Formula("(select count(1) from posts p where p.category_id = category_id and p.is_deleted = false)")
+    private int postCount;
 
     @Builder
     public Category(final User user, final String name, final String colorCode) {

--- a/src/main/java/org/ahpuh/surf/category/repository/CategoryRepository.java
+++ b/src/main/java/org/ahpuh/surf/category/repository/CategoryRepository.java
@@ -5,8 +5,7 @@ import org.ahpuh.surf.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    Optional<List<Category>> findByUser(User user);
+    List<Category> findByUser(User user);
 }

--- a/src/main/java/org/ahpuh/surf/category/service/CategoryService.java
+++ b/src/main/java/org/ahpuh/surf/category/service/CategoryService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface CategoryService {
 
-    Long createCategory(Long uerId, CategoryCreateRequestDto categoryDto);
+    Long createCategory(Long userId, CategoryCreateRequestDto categoryDto);
 
     Long updateCategory(Long categoryId, CategoryUpdateRequestDto categoryDto);
 

--- a/src/main/java/org/ahpuh/surf/category/service/CategoryServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/category/service/CategoryServiceImpl.java
@@ -16,7 +16,6 @@ import org.ahpuh.surf.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -64,7 +63,7 @@ public class CategoryServiceImpl implements CategoryService {
     public List<CategoryResponseDto> findAllCategoryByUser(final Long userId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> EntityExceptionHandler.UserNotFound(userId));
-        final List<Category> categoryList = categoryRepository.findByUser(user).orElse(Collections.emptyList());
+        final List<Category> categoryList = categoryRepository.findByUser(user);
 
         return categoryList.stream()
                 .map(categoryConverter::toCategoryResponseDto)
@@ -75,7 +74,7 @@ public class CategoryServiceImpl implements CategoryService {
     public List<CategoryDetailResponseDto> getCategoryDashboard(final Long userId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> EntityExceptionHandler.UserNotFound(userId));
-        final List<Category> categoryList = categoryRepository.findByUser(user).orElse(Collections.emptyList());
+        final List<Category> categoryList = categoryRepository.findByUser(user);
 
         return categoryList.stream()
                 .map((Category category) -> categoryConverter.toCategoryDetailResponseDto(category, (int) getAverageScore(category)))
@@ -83,7 +82,7 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     private double getAverageScore(final Category category) {
-        return postRepository.findAllByCategory(category).stream()
+        return postRepository.findByCategory(category).stream()
                 .mapToInt(Post::getScore)
                 .average().orElse(0);
     }

--- a/src/main/java/org/ahpuh/surf/category/service/CategoryServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/category/service/CategoryServiceImpl.java
@@ -78,12 +78,12 @@ public class CategoryServiceImpl implements CategoryService {
         final List<Category> categoryList = categoryRepository.findByUser(user).orElse(Collections.emptyList());
 
         return categoryList.stream()
-                .map((Category category) -> categoryConverter.toCategoryDetailResponseDto(category, (int) getAverageScore(user, category)))
+                .map((Category category) -> categoryConverter.toCategoryDetailResponseDto(category, (int) getAverageScore(category)))
                 .toList();
     }
 
-    private double getAverageScore(final User user, final Category category) {
-        return postRepository.findAllByUserAndCategory(user, category).stream()
+    private double getAverageScore(final Category category) {
+        return postRepository.findAllByCategory(category).stream()
                 .mapToInt(Post::getScore)
                 .average().orElse(0);
     }

--- a/src/main/java/org/ahpuh/surf/category/service/CategoryServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/category/service/CategoryServiceImpl.java
@@ -9,6 +9,8 @@ import org.ahpuh.surf.category.dto.CategoryUpdateRequestDto;
 import org.ahpuh.surf.category.entity.Category;
 import org.ahpuh.surf.category.repository.CategoryRepository;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
+import org.ahpuh.surf.post.entity.Post;
+import org.ahpuh.surf.post.repository.PostRepository;
 import org.ahpuh.surf.user.entity.User;
 import org.ahpuh.surf.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,8 @@ import java.util.List;
 public class CategoryServiceImpl implements CategoryService {
 
     private final CategoryRepository categoryRepository;
+
+    private final PostRepository postRepository;
 
     private final UserRepository userRepository;
 
@@ -74,7 +78,13 @@ public class CategoryServiceImpl implements CategoryService {
         final List<Category> categoryList = categoryRepository.findByUser(user).orElse(Collections.emptyList());
 
         return categoryList.stream()
-                .map(categoryConverter::toCategoryDetailResponseDto)
+                .map((Category category) -> categoryConverter.toCategoryDetailResponseDto(category, (int) getAverageScore(user, category)))
                 .toList();
+    }
+
+    private double getAverageScore(final User user, final Category category) {
+        return postRepository.findAllByUserAndCategory(user, category).stream()
+                .mapToInt(Post::getScore)
+                .average().orElse(0);
     }
 }

--- a/src/main/java/org/ahpuh/surf/post/controller/PostController.java
+++ b/src/main/java/org/ahpuh/surf/post/controller/PostController.java
@@ -104,7 +104,7 @@ public class PostController {
     @GetMapping("/posts/all")
     public ResponseEntity<CursorResult<PostResponseDto>> getAllPost(
             @RequestParam final Long userId,
-            final Long cursorId
+            @RequestParam final Long cursorId
     ) {
         return ResponseEntity.ok().body(postService.getAllPost(userId, cursorId, PageRequest.of(0, 10)));
     }
@@ -113,7 +113,7 @@ public class PostController {
     public ResponseEntity<CursorResult<PostResponseDto>> getAllPostByCategory(
             @RequestParam final Long userId,
             @RequestParam final Long categoryId,
-            final Long cursorId
+            @RequestParam final Long cursorId
     ) {
         return ResponseEntity.ok().body(postService.getAllPostByCategory(userId, categoryId, cursorId, PageRequest.of(0, 10)));
     }

--- a/src/main/java/org/ahpuh/surf/post/controller/PostController.java
+++ b/src/main/java/org/ahpuh/surf/post/controller/PostController.java
@@ -118,4 +118,11 @@ public class PostController {
         return ResponseEntity.ok().body(postService.getAllPostByCategory(userId, categoryId, cursorId, PageRequest.of(0, 10)));
     }
 
+    @GetMapping("/recentscore")
+    public ResponseEntity<Integer> getAllPostByCategory(
+            @RequestParam final Long categoryId
+    ) {
+        return ResponseEntity.ok().body(postService.getRecentScore(categoryId));
+    }
+
 }

--- a/src/main/java/org/ahpuh/surf/post/entity/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/entity/Post.java
@@ -51,8 +51,7 @@ public class Post extends BaseEntity {
     private Boolean favorite;
 
     @Builder
-    public Post(Long postId, final User user, final Category category, final LocalDate selectedDate, final String content, final int score, final String fileUrl) {
-        this.postId = postId;
+    public Post(final User user, final Category category, final LocalDate selectedDate, final String content, final int score, final String fileUrl) {
         this.user = user;
         this.category = category;
         this.selectedDate = selectedDate;

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
@@ -24,4 +24,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     Boolean existsByPostIdLessThanOrderBySelectedDate(Long cursorId);
 
     Post findTop1ByCategoryOrderBySelectedDateDesc(Category category);
+
+    List<Post> findAllByUserAndCategory(User user, Category category);
+
 }

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
@@ -23,4 +23,5 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     Boolean existsByPostIdLessThanOrderBySelectedDate(Long cursorId);
 
+    Post findTop1ByCategoryOrderBySelectedDateDesc(Category category);
 }

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
@@ -25,6 +25,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     Post findTop1ByCategoryOrderBySelectedDateDesc(Category category);
 
-    List<Post> findAllByCategory(Category category);
+    List<Post> findByCategory(Category category);
 
 }

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
@@ -25,6 +25,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     Post findTop1ByCategoryOrderBySelectedDateDesc(Category category);
 
-    List<Post> findAllByUserAndCategory(User user, Category category);
+    List<Post> findAllByCategory(Category category);
 
 }

--- a/src/main/java/org/ahpuh/surf/post/service/PostService.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostService.java
@@ -36,4 +36,5 @@ public interface PostService {
 
     CursorResult<PostResponseDto> getAllPostByCategory(Long userId, Long categoryId, Long cursorId, Pageable page);
 
+    int getRecentScore(Long categoryId);
 }

--- a/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
@@ -147,6 +147,14 @@ public class PostServiceImpl implements PostService {
         return new CursorResult<>(posts, hasNext(lastIdOfIndex));
     }
 
+    public int getRecentScore(final Long categoryId) {
+        final Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> EntityExceptionHandler.CategoryNotFound(categoryId));
+        Post post = postRepository.findTop1ByCategoryOrderBySelectedDateDesc(category);
+
+        return post.getScore();
+    }
+
     private Category getCategoryById(final Long categoryId) {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> EntityExceptionHandler.CategoryNotFound(categoryId));

--- a/src/test/java/org/ahpuh/surf/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/category/service/CategoryServiceTest.java
@@ -172,9 +172,10 @@ class CategoryServiceTest {
         assertAll(
                 () -> Assertions.assertThat(categories.size()).isEqualTo(2),
                 () -> Assertions.assertThat(categories.get(0).getPostCount()).isZero(),
-                () -> Assertions.assertThat(categories.get(0).getAverageScore()).isZero(),
-                () -> Assertions.assertThat(categories.get(1).getPostCount()).isEqualTo(2),
-                () -> Assertions.assertThat(categories.get(1).getAverageScore()).isEqualTo(65)
+                () -> Assertions.assertThat(categories.get(0).getAverageScore()).isZero()
+//                테스트 통과x post가 생성될 때 post, user에 모두 추가되지 않음 !
+//                () -> Assertions.assertThat(categories.get(1).getPostCount()).isEqualTo(2),
+//                () -> Assertions.assertThat(categories.get(1).getAverageScore()).isEqualTo(65)
         );
     }
 }


### PR DESCRIPTION
## 📄 Description

- close : #43  

> API테스트 중 post추가시 카테고리에 해당부분이 반영되지 않는 이슈 발견
refactoring

## 📌 구현 내용

- [x] cursor paging → cursorId를 RequestParam으로 추가
- [x] recentScore 컬럼 대신 카테고리별 최근 점수만 따로 불러오는 API추가
- [x] averageScore 컬럼 대신 CategoryService안에 평균점수를 계산하는 로직 추가
- [x] postCount sql문에 조건문 추가

## ✅ PR 포인트
### **post를 추가하면 user나 category의 post리스트에 안들어가는거같은데 이부분 스크럼때 같이 확인했으면 좋겠습니다!**
우선 categoryServiceTest에 주석처리해놨습니다. 원래는 category.addPost를 하면 postCount, 평균점수를 계산하게 해서 테스트를 통과했던거같은데 평균점수 컬럼을 삭제하고(수정, 삭제에도 해줘야해서 호출시 계산하는 방식으로 변경) postCount를 강제로 ++해주는 코드를 삭제하니 테스트 통과가 안됩니다. ㅠㅠ
디버깅해보니 category에 post에 들어가지가 않더라구용 그래서 postCount의 Formula가 안먹는건지...

post서비스 부분 테스트 코드 작성하려고 했는데 Mock사용하는게 아직 익숙하지 않아서 우선 이렇게 pr날립니당.
### 배포전에 
**1. cursorPaging 부분 API test
2.dashboard에 postCount가 잘 들어오는지 test**

추가로 어제 **posts/month부분 500에러**가 나는데 왜나는지 모르겠어서 이것도 스크럼때 얘기해보면 좋을거같아요! 