### PR TITLE
통합테스트 진행하며 발생한 버그 수정

### DIFF
--- a/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
@@ -32,10 +32,6 @@ public class EntityExceptionHandler {
         return new IllegalArgumentException("삭제하려는 팔로우 기록이 없습니다.");
     }
 
-    public static IllegalArgumentException LikeNotFound(final Long likeId) {
-        return new IllegalArgumentException("좋아요한 기록이 없습니다." + likeId);
-    }
-
     public static IllegalArgumentException UserNotMatching(final Long userId, final Long requestUserId) {
         return new IllegalArgumentException(
                 MessageFormat.format("로그인한 회원 id {0}와 요청한 회원의 id {1}가 일치하지 않습니다.", userId, requestUserId)

--- a/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
@@ -32,6 +32,10 @@ public class EntityExceptionHandler {
         return new IllegalArgumentException("삭제하려는 팔로우 기록이 없습니다.");
     }
 
+    public static IllegalArgumentException LikeNotFound() {
+        return new IllegalArgumentException("좋아요한 기록이 없습니다.");
+    }
+
     public static IllegalArgumentException UserNotMatching(final Long userId, final Long requestUserId) {
         return new IllegalArgumentException(
                 MessageFormat.format("로그인한 회원 id {0}와 요청한 회원의 id {1}가 일치하지 않습니다.", userId, requestUserId)

--- a/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/EntityExceptionHandler.java
@@ -32,8 +32,8 @@ public class EntityExceptionHandler {
         return new IllegalArgumentException("삭제하려는 팔로우 기록이 없습니다.");
     }
 
-    public static IllegalArgumentException LikeNotFound() {
-        return new IllegalArgumentException("좋아요한 기록이 없습니다.");
+    public static IllegalArgumentException LikeNotFound(final Long likeId) {
+        return new IllegalArgumentException("좋아요한 기록이 없습니다." + likeId);
     }
 
     public static IllegalArgumentException UserNotMatching(final Long userId, final Long requestUserId) {

--- a/src/main/java/org/ahpuh/surf/like/controller/LikeController.java
+++ b/src/main/java/org/ahpuh/surf/like/controller/LikeController.java
@@ -28,7 +28,7 @@ public class LikeController {
             @PathVariable final Long postId,
             @PathVariable final Long likeId
     ) {
-        likeService.unlike(likeId);
+        likeService.unlike(postId, likeId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/org/ahpuh/surf/like/service/LikeService.java
+++ b/src/main/java/org/ahpuh/surf/like/service/LikeService.java
@@ -4,6 +4,6 @@ public interface LikeService {
 
     Long like(Long userId, Long postId);
 
-    void unlike(Long likeId);
+    void unlike(Long postId, Long likeId);
 
 }

--- a/src/main/java/org/ahpuh/surf/like/service/LikeServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/like/service/LikeServiceImpl.java
@@ -3,11 +3,14 @@ package org.ahpuh.surf.like.service;
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
 import org.ahpuh.surf.like.converter.LikeConverter;
+import org.ahpuh.surf.like.entity.Like;
 import org.ahpuh.surf.like.repository.LikeRepository;
 import org.ahpuh.surf.post.entity.Post;
 import org.ahpuh.surf.post.repository.PostRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +31,11 @@ public class LikeServiceImpl implements LikeService {
     }
 
     @Override
-    public void unlike(final Long likeId) {
+    public void unlike(final Long postId, final Long likeId) {
+        final Like like = likeRepository.findById(likeId).orElseThrow(EntityExceptionHandler::LikeNotFound);
+        if (!Objects.equals(like.getPost().getPostId(), postId)) {
+            throw new IllegalArgumentException("The post ID does not match. " + postId);
+        }
         likeRepository.deleteById(likeId);
     }
 

--- a/src/main/java/org/ahpuh/surf/like/service/LikeServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/like/service/LikeServiceImpl.java
@@ -32,7 +32,7 @@ public class LikeServiceImpl implements LikeService {
 
     @Override
     public void unlike(final Long postId, final Long likeId) {
-        final Like like = likeRepository.findById(likeId).orElseThrow(() -> EntityExceptionHandler.LikeNotFound(likeId));
+        final Like like = likeRepository.findById(likeId).orElseThrow(() -> new IllegalArgumentException("좋아요한 기록이 없습니다." + likeId));
         if (!Objects.equals(like.getPost().getPostId(), postId)) {
             throw new IllegalArgumentException("The post ID does not match. " + postId);
         }

--- a/src/main/java/org/ahpuh/surf/like/service/LikeServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/like/service/LikeServiceImpl.java
@@ -32,7 +32,7 @@ public class LikeServiceImpl implements LikeService {
 
     @Override
     public void unlike(final Long postId, final Long likeId) {
-        final Like like = likeRepository.findById(likeId).orElseThrow(EntityExceptionHandler::LikeNotFound);
+        final Like like = likeRepository.findById(likeId).orElseThrow(() -> EntityExceptionHandler.LikeNotFound(likeId));
         if (!Objects.equals(like.getPost().getPostId(), postId)) {
             throw new IllegalArgumentException("The post ID does not match. " + postId);
         }

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuerydsl {
@@ -17,11 +18,11 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     List<Post> findAllByUserAndSelectedDateBetweenOrderBySelectedDate(User user, LocalDate start, LocalDate end);
 
-    List<Post> findByUserAndPostIdLessThanOrderBySelectedDateDesc(User user, Long cursorId, Pageable page);
+    List<Post> findByUserAndSelectedDateLessThanAndCreatedAtLessThanOrderBySelectedDate(User user, LocalDate selectedDate, LocalDateTime createdAt, Pageable page);
 
-    List<Post> findByUserAndCategoryAndPostIdLessThanOrderBySelectedDateDesc(User user, Category category, Long cursorId, Pageable page);
+    List<Post> findByUserAndCategoryAndSelectedDateLessThanAndCreatedAtLessThanOrderBySelectedDate(User user, Category category, LocalDate selectedDate, LocalDateTime createdAt, Pageable page);
 
-    Boolean existsByPostIdLessThanOrderBySelectedDate(Long cursorId);
+    Boolean existsBySelectedDateLessThanAndCreatedAtLessThan(LocalDate selectedDate, LocalDateTime createdAt);
 
     Post findTop1ByCategoryOrderBySelectedDateDesc(Category category);
 

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryImpl.java
@@ -33,9 +33,9 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                 ))
                 .from(post)
                 .leftJoin(follow).on(follow.user.userId.eq(userId))
-                .where(follow.followedUser.userId.eq(post.user.userId))
+                .where(follow.followedUser.userId.eq(post.user.userId), post.isDeleted.eq(false))
                 .groupBy(post.postId, follow.followId)
-                .orderBy(post.updatedAt.desc())
+                .orderBy(post.selectedDate.desc())
                 .fetch();
     }
 
@@ -47,7 +47,7 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                         post.selectedDate.count().as("count")))
                 .from(post)
                 .where(post.selectedDate.between(LocalDate.of(year, 1, 1), LocalDate.of(year, 12, 31)),
-                        post.user.eq(user))
+                        post.user.eq(user), post.isDeleted.eq(false))
                 .groupBy(post.selectedDate)
                 .orderBy(post.selectedDate.asc())
                 .fetch();
@@ -62,7 +62,7 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                         post.score.as("score")
                 ))
                 .from(post)
-                .where(post.user.eq(user))
+                .where(post.user.eq(user), post.isDeleted.eq(false))
                 .orderBy(post.category.categoryId.asc(), post.selectedDate.asc())
                 .fetch();
     }

--- a/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryQuerydsl.java
+++ b/src/main/java/org/ahpuh/surf/post/repository/PostRepositoryQuerydsl.java
@@ -4,12 +4,17 @@ import org.ahpuh.surf.post.dto.FollowingPostDto;
 import org.ahpuh.surf.post.dto.PostCountDto;
 import org.ahpuh.surf.post.dto.PostScoreCategoryDto;
 import org.ahpuh.surf.user.entity.User;
+import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostRepositoryQuerydsl {
 
-    List<FollowingPostDto> findFollowingPosts(Long userId);
+    List<FollowingPostDto> findFollowingPosts(Long userId, Pageable page);
+
+    List<FollowingPostDto> findNextFollowingPosts(Long userId, LocalDate selectedDate, LocalDateTime createdAt, Pageable page);
 
     List<PostCountDto> findAllDateAndCountBetween(int year, User user);
 

--- a/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
@@ -122,12 +122,13 @@ public class PostServiceImpl implements PostService {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> EntityExceptionHandler.UserNotFound(userId));
 
-        final List<Post> postList = cursorId == 0 ?
-                postRepository.findAllByUserOrderBySelectedDateDesc(user, page) :
-                postRepository.findByUserAndPostIdLessThanOrderBySelectedDateDesc(user, cursorId, page);
+        final Post findPost = postRepository.findById(cursorId).orElse(null);
 
-        final Long lastIdOfIndex = postList.isEmpty() ?
-                null : postList.get(postList.size() - 1).getPostId();
+        final List<Post> postList = findPost == null ?
+                postRepository.findAllByUserOrderBySelectedDateDesc(user, page) :
+                postRepository.findByUserAndSelectedDateLessThanAndCreatedAtLessThanOrderBySelectedDate(user, findPost.getSelectedDate(), findPost.getCreatedAt(), page);
+
+        final Long lastIdOfIndex = postList.isEmpty() ? 0 : postList.get(postList.size() - 1).getPostId();
 
         final List<AllPostResponseDto> posts = postList.stream()
                 .map(post -> postConverter.toAllPostResponseDto(post, likeRepository.findByUserIdAndPost(myId, post)))
@@ -143,12 +144,13 @@ public class PostServiceImpl implements PostService {
         final Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> EntityExceptionHandler.CategoryNotFound(categoryId));
 
-        final List<Post> postList = cursorId == 0 ?
-                postRepository.findAllByUserAndCategoryOrderBySelectedDateDesc(user, category, page) :
-                postRepository.findByUserAndCategoryAndPostIdLessThanOrderBySelectedDateDesc(user, category, cursorId, page);
+        final Post findPost = postRepository.findById(cursorId).orElse(null);
 
-        final Long lastIdOfIndex = postList.isEmpty() ?
-                null : postList.get(postList.size() - 1).getPostId();
+        final List<Post> postList = findPost == null ?
+                postRepository.findAllByUserAndCategoryOrderBySelectedDateDesc(user, category, page) :
+                postRepository.findByUserAndCategoryAndSelectedDateLessThanAndCreatedAtLessThanOrderBySelectedDate(user, category, findPost.getSelectedDate(), findPost.getCreatedAt(), page);
+
+        final Long lastIdOfIndex = postList.isEmpty() ? 0 : postList.get(postList.size() - 1).getPostId();
 
         final List<AllPostResponseDto> posts = postList.stream()
                 .map(post -> postConverter.toAllPostResponseDto(post, likeRepository.findByUserIdAndPost(myId, post)))
@@ -176,7 +178,8 @@ public class PostServiceImpl implements PostService {
     }
 
     private Boolean hasNext(final Long id) {
-        return id != null && postRepository.existsByPostIdLessThanOrderBySelectedDate(id);
+        final Post post = postRepository.findById(id).orElse(null);
+        return post != null && postRepository.existsBySelectedDateLessThanAndCreatedAtLessThan(post.getSelectedDate(), post.getCreatedAt());
     }
 
 }

--- a/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostServiceImpl.java
@@ -75,7 +75,13 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public CursorResult<FollowingPostDto> explore(final Long myId, final Long cursorId, final Pageable page) {
-        final List<FollowingPostDto> followingPostDtos = postRepository.findFollowingPosts(myId);
+
+        final Post findPost = postRepository.findById(cursorId).orElse(null);
+
+        final List<FollowingPostDto> followingPostDtos = findPost == null ?
+                postRepository.findFollowingPosts(myId, page) :
+                postRepository.findNextFollowingPosts(myId, findPost.getSelectedDate(), findPost.getCreatedAt(), page);
+
         for (final FollowingPostDto dto : followingPostDtos) {
             likeRepository.findByUserIdAndPost(myId, getPostById(dto.getPostId()))
                     .ifPresent(like -> dto.setLiked(like.getLikeId()));

--- a/src/test/java/org/ahpuh/surf/post/repository/PostRepositoryTest.java
+++ b/src/test/java/org/ahpuh/surf/post/repository/PostRepositoryTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -98,28 +99,28 @@ class PostRepositoryTest {
         postRepository.save(Post.builder()
                 .user(user2)
                 .category(category1)
-                .selectedDate(LocalDate.now())
+                .selectedDate(LocalDate.of(2020, 12, 12))
                 .content("content1")
                 .score(80)
                 .build());
         postRepository.save(Post.builder()
                 .user(user3)
                 .category(category2)
-                .selectedDate(LocalDate.now())
+                .selectedDate(LocalDate.of(2021, 2, 1))
                 .content("content2")
                 .score(80)
                 .build());
         postRepository.save(Post.builder()
                 .user(user1)
                 .category(category2)
-                .selectedDate(LocalDate.now())
+                .selectedDate(LocalDate.of(2021, 3, 3))
                 .content("content4")
                 .score(80)
                 .build());
         postRepository.save(Post.builder()
                 .user(user2)
                 .category(category1)
-                .selectedDate(LocalDate.now())
+                .selectedDate(LocalDate.of(2021, 8, 8))
                 .content("content3")
                 .score(80)
                 .build());
@@ -171,7 +172,7 @@ class PostRepositoryTest {
         );
 
         // JpaRepository에 Querydsl 적용 test
-        final List<FollowingPostDto> findByJpaRepo = postRepository.findFollowingPosts(userId1);
+        final List<FollowingPostDto> findByJpaRepo = postRepository.findFollowingPosts(userId1, PageRequest.of(0, 10));
 
         assertAll("follow한 사용자의 모든 posts in repository",
                 () -> assertThat(findByJpaRepo.size(), is(3)),


### PR DESCRIPTION
## 📄 Description

- close : #55 

> 통합 테스트 진행하며 발생한 버그 수정
1. 커서페이징 정렬 오류 수정
2. 커서페이징 hasNext 수정
3. querydsl 삭제된 데이터가 조회되는 오류 수정
4. file에 null입력 시 500에러가 나는 부분 -> 수정 필요

## 📌 구현 내용

- [x]  일년치 게시글 점수 조회
- [x] 한달 전체 게시글 조회
- [x] 전체 게시글 조회 커서 페이징으로 정렬되어 나타나는지 확인
- [x] 카테고리별 게시글 조회 커서페이징으로 정렬되어 나타나는지 확인
- [x] 팔로우 한 사용자 게시글 전체 조회
- [x] 게시글 좋아요 취소 /posts/{postId}/unlike/{likeId} postId에 대한 validation추가

## ✅ PR 포인트

[통합테스트 시나리오](https://www.notion.so/backend-devcourse/78f0b3fe05f74c488bf8f23dba4018bd) 참고해주세요!