### PR TITLE
request와 response를 전부 객체로 수정

### DIFF
--- a/src/main/java/org/ahpuh/surf/category/controller/CategoryController.java
+++ b/src/main/java/org/ahpuh/surf/category/controller/CategoryController.java
@@ -3,8 +3,10 @@ package org.ahpuh.surf.category.controller;
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
 import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.ahpuh.surf.category.dto.response.AllCategoryByUserResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryCreateResponseDto;
 import org.ahpuh.surf.category.dto.response.CategoryDetailResponseDto;
-import org.ahpuh.surf.category.dto.response.CategoryResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryUpdateResponseDto;
 import org.ahpuh.surf.category.service.CategoryService;
 import org.ahpuh.surf.jwt.JwtAuthentication;
 import org.springframework.http.ResponseEntity;
@@ -23,21 +25,21 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @PostMapping
-    public ResponseEntity<Long> createCategory(
+    public ResponseEntity<CategoryCreateResponseDto> createCategory(
             @AuthenticationPrincipal final JwtAuthentication authentication,
             @Valid @RequestBody final CategoryCreateRequestDto request
     ) {
-        final Long categoryId = categoryService.createCategory(authentication.userId, request);
-        return ResponseEntity.created(URI.create("/api/v1/categories" + categoryId)).body(categoryId);
+        final CategoryCreateResponseDto response = categoryService.createCategory(authentication.userId, request);
+        return ResponseEntity.created(URI.create("/api/v1/categories" + response)).body(response);
     }
 
     @PutMapping("/{categoryId}")
-    public ResponseEntity<Long> updateCategory(
+    public ResponseEntity<CategoryUpdateResponseDto> updateCategory(
             @PathVariable final Long categoryId,
             @Valid @RequestBody final CategoryUpdateRequestDto request
     ) {
-        final Long id = categoryService.updateCategory(categoryId, request);
-        return ResponseEntity.ok().body(id);
+        final CategoryUpdateResponseDto response = categoryService.updateCategory(categoryId, request);
+        return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/{categoryId}")
@@ -49,7 +51,7 @@ public class CategoryController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CategoryResponseDto>> findAllCategoryByUser(
+    public ResponseEntity<List<AllCategoryByUserResponseDto>> findAllCategoryByUser(
             @AuthenticationPrincipal final JwtAuthentication authentication
     ) {
         final Long userId = authentication.userId;

--- a/src/main/java/org/ahpuh/surf/category/converter/CategoryConverter.java
+++ b/src/main/java/org/ahpuh/surf/category/converter/CategoryConverter.java
@@ -1,8 +1,8 @@
 package org.ahpuh.surf.category.converter;
 
 import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
+import org.ahpuh.surf.category.dto.response.AllCategoryByUserResponseDto;
 import org.ahpuh.surf.category.dto.response.CategoryDetailResponseDto;
-import org.ahpuh.surf.category.dto.response.CategoryResponseDto;
 import org.ahpuh.surf.category.entity.Category;
 import org.ahpuh.surf.user.entity.User;
 import org.springframework.stereotype.Component;
@@ -18,8 +18,8 @@ public class CategoryConverter {
                 .build();
     }
 
-    public CategoryResponseDto toCategoryResponseDto(final Category category) {
-        return CategoryResponseDto.builder()
+    public AllCategoryByUserResponseDto toCategoryResponseDto(final Category category) {
+        return AllCategoryByUserResponseDto.builder()
                 .categoryId(category.getCategoryId())
                 .name(category.getName())
                 .isPublic(category.getIsPublic())

--- a/src/main/java/org/ahpuh/surf/category/dto/response/AllCategoryByUserResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/category/dto/response/AllCategoryByUserResponseDto.java
@@ -1,0 +1,19 @@
+package org.ahpuh.surf.category.dto.response;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class AllCategoryByUserResponseDto {
+
+    private Long categoryId;
+
+    private String name;
+
+    private Boolean isPublic;
+
+    private String colorCode;
+
+}

--- a/src/main/java/org/ahpuh/surf/category/dto/response/CategoryCreateResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/category/dto/response/CategoryCreateResponseDto.java
@@ -1,0 +1,15 @@
+package org.ahpuh.surf.category.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class CategoryCreateResponseDto {
+
+    private Long categoryId;
+    
+}

--- a/src/main/java/org/ahpuh/surf/category/dto/response/CategoryUpdateResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/category/dto/response/CategoryUpdateResponseDto.java
@@ -1,19 +1,15 @@
 package org.ahpuh.surf.category.dto.response;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class CategoryResponseDto {
+public class CategoryUpdateResponseDto {
 
     private Long categoryId;
-
-    private String name;
-
-    private Boolean isPublic;
-
-    private String colorCode;
 
 }

--- a/src/main/java/org/ahpuh/surf/category/service/CategoryService.java
+++ b/src/main/java/org/ahpuh/surf/category/service/CategoryService.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.category.converter.CategoryConverter;
 import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
 import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.ahpuh.surf.category.dto.response.AllCategoryByUserResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryCreateResponseDto;
 import org.ahpuh.surf.category.dto.response.CategoryDetailResponseDto;
-import org.ahpuh.surf.category.dto.response.CategoryResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryUpdateResponseDto;
 import org.ahpuh.surf.category.entity.Category;
 import org.ahpuh.surf.category.repository.CategoryRepository;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
@@ -29,21 +31,22 @@ public class CategoryService {
     private final CategoryConverter categoryConverter;
 
     @Transactional
-    public Long createCategory(final Long userId, final CategoryCreateRequestDto categoryDto) {
+    public CategoryCreateResponseDto createCategory(final Long userId, final CategoryCreateRequestDto categoryDto) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> EntityExceptionHandler.UserNotFound(userId));
         final Category category = categoryConverter.toEntity(user, categoryDto);
+        final Long categoryId = categoryRepository.save(category).getCategoryId();
 
-        return categoryRepository.save(category).getCategoryId();
+        return new CategoryCreateResponseDto(categoryId);
     }
 
     @Transactional
-    public Long updateCategory(final Long categoryId, final CategoryUpdateRequestDto categoryDto) {
+    public CategoryUpdateResponseDto updateCategory(final Long categoryId, final CategoryUpdateRequestDto categoryDto) {
         final Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> EntityExceptionHandler.CategoryNotFound(categoryId));
         category.update(categoryDto.getName(), categoryDto.getIsPublic(), categoryDto.getColorCode());
 
-        return category.getCategoryId();
+        return new CategoryUpdateResponseDto(categoryId);
     }
 
     @Transactional
@@ -53,7 +56,7 @@ public class CategoryService {
         categoryRepository.delete(category);
     }
 
-    public List<CategoryResponseDto> findAllCategoryByUser(final Long userId) {
+    public List<AllCategoryByUserResponseDto> findAllCategoryByUser(final Long userId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> EntityExceptionHandler.UserNotFound(userId));
         final List<Category> categoryList = categoryRepository.findByUser(user);

--- a/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
+++ b/src/main/java/org/ahpuh/surf/follow/controller/FollowController.java
@@ -2,6 +2,7 @@ package org.ahpuh.surf.follow.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.follow.dto.FollowUserDto;
+import org.ahpuh.surf.follow.dto.response.FollowResponseDto;
 import org.ahpuh.surf.follow.service.FollowService;
 import org.ahpuh.surf.jwt.JwtAuthentication;
 import org.springframework.http.ResponseEntity;
@@ -19,13 +20,13 @@ public class FollowController {
     private final FollowService followService;
 
     @PostMapping("/follow")
-    public ResponseEntity<Long> follow(
+    public ResponseEntity<FollowResponseDto> follow(
             @AuthenticationPrincipal final JwtAuthentication authentication,
             @RequestBody final Long followUserId
     ) {
-        final Long followId = followService.follow(authentication.userId, followUserId);
+        final FollowResponseDto response = followService.follow(authentication.userId, followUserId);
         return ResponseEntity.created(URI.create("/api/v1/users/" + authentication.userId + "/following"))
-                .body(followId);
+                .body(response);
     }
 
     @DeleteMapping("/follow/{userId}")
@@ -52,5 +53,4 @@ public class FollowController {
         final List<FollowUserDto> response = followService.findFollowingList(userId);
         return ResponseEntity.ok().body(response);
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/follow/dto/response/FollowResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/follow/dto/response/FollowResponseDto.java
@@ -1,0 +1,15 @@
+package org.ahpuh.surf.follow.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class FollowResponseDto {
+
+    private Long followId;
+
+}

--- a/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
+++ b/src/main/java/org/ahpuh/surf/follow/service/FollowService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
 import org.ahpuh.surf.follow.converter.FollowConverter;
 import org.ahpuh.surf.follow.dto.FollowUserDto;
+import org.ahpuh.surf.follow.dto.response.FollowResponseDto;
 import org.ahpuh.surf.follow.entity.Follow;
 import org.ahpuh.surf.follow.repository.FollowRepository;
 import org.ahpuh.surf.user.entity.User;
@@ -25,14 +26,16 @@ public class FollowService {
     private final FollowConverter followConverter;
 
     @Transactional
-    public Long follow(final Long userId, final Long followUserId) {
+    public FollowResponseDto follow(final Long userId, final Long followUserId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFound(userId));
         final User followedUser = userRepository.findById(followUserId)
                 .orElseThrow(() -> UserNotFound(followUserId));
 
-        return followRepository.save(followConverter.toEntity(user, followedUser))
+        final Long followId = followRepository.save(followConverter.toEntity(user, followedUser))
                 .getFollowId();
+
+        return new FollowResponseDto(followId);
     }
 
     @Transactional

--- a/src/main/java/org/ahpuh/surf/like/controller/LikeController.java
+++ b/src/main/java/org/ahpuh/surf/like/controller/LikeController.java
@@ -2,6 +2,7 @@ package org.ahpuh.surf.like.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.jwt.JwtAuthentication;
+import org.ahpuh.surf.like.dto.response.LikeResponseDto;
 import org.ahpuh.surf.like.service.LikeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,12 +16,12 @@ public class LikeController {
     private final LikeService likeService;
 
     @PostMapping("/like")
-    public ResponseEntity<Long> like(
+    public ResponseEntity<LikeResponseDto> like(
             @AuthenticationPrincipal final JwtAuthentication authentication,
             @PathVariable final Long postId
     ) {
-        final Long likeId = likeService.like(authentication.userId, postId);
-        return ResponseEntity.ok().body(likeId);
+        final LikeResponseDto response = likeService.like(authentication.userId, postId);
+        return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/unlike/{likeId}")
@@ -31,5 +32,4 @@ public class LikeController {
         likeService.unlike(postId, likeId);
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/like/dto/response/LikeResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/like/dto/response/LikeResponseDto.java
@@ -1,0 +1,15 @@
+package org.ahpuh.surf.like.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class LikeResponseDto {
+
+    private Long likeId;
+
+}

--- a/src/main/java/org/ahpuh/surf/like/service/LikeService.java
+++ b/src/main/java/org/ahpuh/surf/like/service/LikeService.java
@@ -3,6 +3,7 @@ package org.ahpuh.surf.like.service;
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
 import org.ahpuh.surf.like.converter.LikeConverter;
+import org.ahpuh.surf.like.dto.response.LikeResponseDto;
 import org.ahpuh.surf.like.entity.Like;
 import org.ahpuh.surf.like.repository.LikeRepository;
 import org.ahpuh.surf.post.entity.Post;
@@ -24,13 +25,16 @@ public class LikeService {
     private final PostRepository postRepository;
     private final LikeConverter likeConverter;
 
-    public Long like(final Long userId, final Long postId) {
+    public LikeResponseDto like(final Long userId, final Long postId) {
         final User userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> EntityExceptionHandler.UserNotFound(userId));
         final Post postEntity = postRepository.findById(postId)
                 .orElseThrow(() -> EntityExceptionHandler.PostNotFound(postId));
-        return likeRepository.save(likeConverter.toEntity(userEntity, postEntity))
+
+        final Long likeId = likeRepository.save(likeConverter.toEntity(userEntity, postEntity))
                 .getLikeId();
+
+        return new LikeResponseDto(likeId);
     }
 
     public void unlike(final Long postId, final Long likeId) {

--- a/src/main/java/org/ahpuh/surf/post/converter/PostConverter.java
+++ b/src/main/java/org/ahpuh/surf/post/converter/PostConverter.java
@@ -4,12 +4,12 @@ import org.ahpuh.surf.category.dto.CategorySimpleDto;
 import org.ahpuh.surf.category.entity.Category;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
 import org.ahpuh.surf.common.s3.S3ServiceImpl.FileStatus;
-import org.ahpuh.surf.post.dto.PostDto;
 import org.ahpuh.surf.post.dto.PostScoreCategoryDto;
 import org.ahpuh.surf.post.dto.PostScoreDto;
 import org.ahpuh.surf.post.dto.RecentPostDto;
 import org.ahpuh.surf.post.dto.request.PostRequestDto;
 import org.ahpuh.surf.post.dto.response.AllPostResponseDto;
+import org.ahpuh.surf.post.dto.response.PostReadResponseDto;
 import org.ahpuh.surf.post.dto.response.PostResponseDto;
 import org.ahpuh.surf.post.entity.Post;
 import org.ahpuh.surf.user.entity.User;
@@ -37,8 +37,8 @@ public class PostConverter {
         return postEntity;
     }
 
-    public PostDto toDto(final Post post, final Long myId) {
-        final PostDto dto = PostDto.builder()
+    public PostReadResponseDto toPostReadResponseDto(final Post post, final Long myId) {
+        final PostReadResponseDto dto = PostReadResponseDto.builder()
                 .postId(post.getPostId())
                 .userId(post.getUser().getUserId())
                 .categoryId(post.getCategory().getCategoryId())
@@ -151,5 +151,4 @@ public class PostConverter {
         }
         return recentPostDto;
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/post/dto/response/PostCreateResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/post/dto/response/PostCreateResponseDto.java
@@ -1,0 +1,12 @@
+package org.ahpuh.surf.post.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class PostCreateResponseDto {
+
+    private Long postId;
+
+}

--- a/src/main/java/org/ahpuh/surf/post/dto/response/PostFavoriteResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/post/dto/response/PostFavoriteResponseDto.java
@@ -1,0 +1,15 @@
+package org.ahpuh.surf.post.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class PostFavoriteResponseDto {
+
+    private Long postId;
+
+}

--- a/src/main/java/org/ahpuh/surf/post/dto/response/PostReadResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/post/dto/response/PostReadResponseDto.java
@@ -1,4 +1,4 @@
-package org.ahpuh.surf.post.dto;
+package org.ahpuh.surf.post.dto.response;
 
 import lombok.*;
 
@@ -6,7 +6,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class PostDto {
+public class PostReadResponseDto {
 
     private Long postId;
 

--- a/src/main/java/org/ahpuh/surf/post/dto/response/PostUpdateResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/post/dto/response/PostUpdateResponseDto.java
@@ -1,0 +1,15 @@
+package org.ahpuh.surf.post.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class PostUpdateResponseDto {
+
+    private Long postId;
+
+}

--- a/src/main/java/org/ahpuh/surf/post/dto/response/PostsRecentScoreResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/post/dto/response/PostsRecentScoreResponseDto.java
@@ -1,0 +1,15 @@
+package org.ahpuh.surf.post.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class PostsRecentScoreResponseDto {
+
+    private Integer recentScore;
+
+}

--- a/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
+++ b/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
@@ -1,8 +1,9 @@
 package org.ahpuh.surf.user.converter;
 
 import lombok.RequiredArgsConstructor;
-import org.ahpuh.surf.user.dto.UserDto;
 import org.ahpuh.surf.user.dto.request.UserJoinRequestDto;
+import org.ahpuh.surf.user.dto.response.UserFindInfoResponseDto;
+import org.ahpuh.surf.user.dto.response.UserJoinResponseDto;
 import org.ahpuh.surf.user.entity.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -21,8 +22,12 @@ public class UserConverter {
                 .build();
     }
 
-    public UserDto toUserDto(final User userEntity, final long followingCount, final long followerCount) {
-        return UserDto.builder()
+    public UserJoinResponseDto toUserJoinResponseDto(final Long userId) {
+        return new UserJoinResponseDto(userId);
+    }
+
+    public UserFindInfoResponseDto toUserFindInfoResponseDto(final User userEntity, final long followingCount, final long followerCount) {
+        return UserFindInfoResponseDto.builder()
                 .userId(userEntity.getUserId())
                 .email(userEntity.getEmail())
                 .userName(userEntity.getUserName())
@@ -34,5 +39,4 @@ public class UserConverter {
                 .accountPublic(userEntity.getAccountPublic())
                 .build();
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
+++ b/src/main/java/org/ahpuh/surf/user/converter/UserConverter.java
@@ -3,7 +3,6 @@ package org.ahpuh.surf.user.converter;
 import lombok.RequiredArgsConstructor;
 import org.ahpuh.surf.user.dto.request.UserJoinRequestDto;
 import org.ahpuh.surf.user.dto.response.UserFindInfoResponseDto;
-import org.ahpuh.surf.user.dto.response.UserJoinResponseDto;
 import org.ahpuh.surf.user.entity.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -20,10 +19,6 @@ public class UserConverter {
                 .password(bCryptEncoder.encode(dto.getPassword()))
                 .userName(dto.getUserName())
                 .build();
-    }
-
-    public UserJoinResponseDto toUserJoinResponseDto(final Long userId) {
-        return new UserJoinResponseDto(userId);
     }
 
     public UserFindInfoResponseDto toUserFindInfoResponseDto(final User userEntity, final long followingCount, final long followerCount) {

--- a/src/main/java/org/ahpuh/surf/user/dto/response/UserFindInfoResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/user/dto/response/UserFindInfoResponseDto.java
@@ -1,4 +1,4 @@
-package org.ahpuh.surf.user.dto;
+package org.ahpuh.surf.user.dto.response;
 
 import lombok.*;
 
@@ -6,7 +6,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Builder
-public class UserDto {
+public class UserFindInfoResponseDto {
 
     private Long userId;
 

--- a/src/main/java/org/ahpuh/surf/user/dto/response/UserUpdateResponseDto.java
+++ b/src/main/java/org/ahpuh/surf/user/dto/response/UserUpdateResponseDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-public class UserJoinResponseDto {
+public class UserUpdateResponseDto {
 
     private Long userId;
 

--- a/src/main/java/org/ahpuh/surf/user/service/UserService.java
+++ b/src/main/java/org/ahpuh/surf/user/service/UserService.java
@@ -5,10 +5,12 @@ import org.ahpuh.surf.follow.repository.FollowRepository;
 import org.ahpuh.surf.jwt.JwtAuthentication;
 import org.ahpuh.surf.jwt.JwtAuthenticationToken;
 import org.ahpuh.surf.user.converter.UserConverter;
-import org.ahpuh.surf.user.dto.UserDto;
 import org.ahpuh.surf.user.dto.request.UserJoinRequestDto;
 import org.ahpuh.surf.user.dto.request.UserUpdateRequestDto;
+import org.ahpuh.surf.user.dto.response.UserFindInfoResponseDto;
+import org.ahpuh.surf.user.dto.response.UserJoinResponseDto;
 import org.ahpuh.surf.user.dto.response.UserLoginResponseDto;
+import org.ahpuh.surf.user.dto.response.UserUpdateResponseDto;
 import org.ahpuh.surf.user.entity.User;
 import org.ahpuh.surf.user.repository.UserRepository;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -47,28 +49,28 @@ public class UserService {
     }
 
     @Transactional
-    public Long join(final UserJoinRequestDto joinRequest) {
+    public UserJoinResponseDto join(final UserJoinRequestDto joinRequest) {
         if (userRepository.existsByEmail(joinRequest.getEmail())) {
             throw new IllegalArgumentException(String.format("Email is duplicated. email=%s", joinRequest.getEmail()));
         }
-        final User newUser = userRepository.save(userConverter.toEntity(joinRequest));
-        return newUser.getUserId();
+        final User userEntity = userRepository.save(userConverter.toEntity(joinRequest));
+        return userConverter.toUserJoinResponseDto(userEntity.getUserId());
     }
 
-    public UserDto findById(final Long userId) {
+    public UserFindInfoResponseDto findUser(final Long userId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFound(userId));
         final long followingCount = followRepository.countByUser(user);
         final long followerCount = followRepository.countByFollowedUser(user);
-        return userConverter.toUserDto(user, followingCount, followerCount);
+        return userConverter.toUserFindInfoResponseDto(user, followingCount, followerCount);
     }
 
     @Transactional
-    public Long update(final Long userId, final UserUpdateRequestDto updateDto, final String profilePhotoUrl) {
+    public UserUpdateResponseDto update(final Long userId, final UserUpdateRequestDto updateDto, final String profilePhotoUrl) {
         final User userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFound(userId));
         userEntity.update(passwordEncoder, updateDto, profilePhotoUrl);
-        return userEntity.getUserId();
+        return new UserUpdateResponseDto(userId);
     }
 
     @Transactional

--- a/src/main/java/org/ahpuh/surf/user/service/UserService.java
+++ b/src/main/java/org/ahpuh/surf/user/service/UserService.java
@@ -53,8 +53,9 @@ public class UserService {
         if (userRepository.existsByEmail(joinRequest.getEmail())) {
             throw new IllegalArgumentException(String.format("Email is duplicated. email=%s", joinRequest.getEmail()));
         }
-        final User userEntity = userRepository.save(userConverter.toEntity(joinRequest));
-        return userConverter.toUserJoinResponseDto(userEntity.getUserId());
+        final Long userId = userRepository.save(userConverter.toEntity(joinRequest))
+                .getUserId();
+        return new UserJoinResponseDto(userId);
     }
 
     public UserFindInfoResponseDto findUser(final Long userId) {

--- a/src/test/java/org/ahpuh/surf/integration/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/category/service/CategoryServiceTest.java
@@ -2,8 +2,8 @@ package org.ahpuh.surf.integration.category.service;
 
 import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
 import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.ahpuh.surf.category.dto.response.AllCategoryByUserResponseDto;
 import org.ahpuh.surf.category.dto.response.CategoryDetailResponseDto;
-import org.ahpuh.surf.category.dto.response.CategoryResponseDto;
 import org.ahpuh.surf.category.entity.Category;
 import org.ahpuh.surf.category.repository.CategoryRepository;
 import org.ahpuh.surf.category.service.CategoryService;
@@ -124,7 +124,7 @@ class CategoryServiceTest {
         final Long id = user.getUserId();
 
         // when
-        final List<CategoryResponseDto> categories = categoryService.findAllCategoryByUser(id);
+        final List<AllCategoryByUserResponseDto> categories = categoryService.findAllCategoryByUser(id);
 
         // then
         assertAll(

--- a/src/test/java/org/ahpuh/surf/integration/post/PostTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/post/PostTest.java
@@ -124,7 +124,8 @@ public class PostTest {
                         .password(pw)
                         .userName("name")
                         .build())
-                .getBody();
+                .getBody()
+                .getUserId();
     }
 
     private Category saveCategory(final User user, final String categoryName) {

--- a/src/test/java/org/ahpuh/surf/unit/post/service/PostServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/service/PostServiceTest.java
@@ -100,7 +100,7 @@ class PostServiceTest {
                 .thenReturn(post);
 
         // when
-        final Long response = postService.create(userId, request, null);
+        postService.create(userId, request, null);
 
         // then
         assertAll(


### PR DESCRIPTION
## 📄 Description

- close : #80 

> request와 response를 전부 객체로 수정합니다.
> - dto로 관리하기 위함.
> - restdocs 문서화 진행시 responseFields 가 1개인 경우 문서화 불가능한 문제 직면.

## 📌 구현 내용

- [x] User 도메인 request, response 수정
- [x] Category 도메인 request, response 수정
- [x] Post 도메인 request, response 수정
- [x] Follow 도메인 request, response 수정
- [x] Like 도메인 request, response 수정
