### PR TITLE
Category 도메인 단위 테스트

### DIFF
--- a/src/test/java/org/ahpuh/surf/common/factory/MockCategoryFactory.java
+++ b/src/test/java/org/ahpuh/surf/common/factory/MockCategoryFactory.java
@@ -1,6 +1,12 @@
 package org.ahpuh.surf.common.factory;
 
 import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
+import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.ahpuh.surf.category.dto.response.AllCategoryByUserResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryCreateResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryDetailResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryUpdateResponseDto;
 import org.ahpuh.surf.user.domain.User;
 
 public class MockCategoryFactory {
@@ -9,8 +15,50 @@ public class MockCategoryFactory {
         return Category.builder()
                 .user(user)
                 .name("categoryName")
-                .colorCode("000000")
+                .colorCode("#000000")
                 .build();
     }
 
+    public static CategoryCreateRequestDto createMockCategoryCreateRequestDto() {
+        return CategoryCreateRequestDto.builder()
+                .name("categoryName")
+                .colorCode("#000000")
+                .build();
+    }
+
+    public static CategoryCreateResponseDto createMockCategoryCreateResponseDto() {
+        return new CategoryCreateResponseDto(1L);
+    }
+
+    public static CategoryUpdateRequestDto createMockCategoryUpdateRequestDto() {
+        return CategoryUpdateRequestDto.builder()
+                .name("categoryName")
+                .colorCode("#000000")
+                .isPublic(true)
+                .build();
+    }
+
+    public static CategoryUpdateResponseDto createMockCategoryUpdateResponseDto() {
+        return new CategoryUpdateResponseDto(1L);
+    }
+
+    public static AllCategoryByUserResponseDto createMockAllCategoryByUserResponseDto() {
+        return AllCategoryByUserResponseDto.builder()
+                .categoryId(1L)
+                .name("categoryName")
+                .colorCode("#000000")
+                .isPublic(true)
+                .build();
+    }
+
+    public static CategoryDetailResponseDto createMockCategoryDetailResponseDto() {
+        return CategoryDetailResponseDto.builder()
+                .categoryId(1L)
+                .name("categoryName")
+                .colorCode("#000000")
+                .isPublic(true)
+                .averageScore(90)
+                .postCount(3)
+                .build();
+    }
 }

--- a/src/test/java/org/ahpuh/surf/common/factory/MockPostFactory.java
+++ b/src/test/java/org/ahpuh/surf/common/factory/MockPostFactory.java
@@ -18,4 +18,7 @@ public class MockPostFactory {
                 .build();
     }
 
+    public static Post createMockScoredPost(final User user, final Category category, final int score) {
+        return new Post(user, category, null, null, score);
+    }
 }

--- a/src/test/java/org/ahpuh/surf/common/factory/MockUserFactory.java
+++ b/src/test/java/org/ahpuh/surf/common/factory/MockUserFactory.java
@@ -1,5 +1,6 @@
 package org.ahpuh.surf.common.factory;
 
+import org.ahpuh.surf.user.domain.Permission;
 import org.ahpuh.surf.user.domain.User;
 import org.ahpuh.surf.user.dto.request.UserJoinRequestDto;
 import org.ahpuh.surf.user.dto.request.UserLoginRequestDto;
@@ -8,6 +9,8 @@ import org.ahpuh.surf.user.dto.response.UserFindInfoResponseDto;
 import org.ahpuh.surf.user.dto.response.UserJoinResponseDto;
 import org.ahpuh.surf.user.dto.response.UserLoginResponseDto;
 import org.ahpuh.surf.user.dto.response.UserUpdateResponseDto;
+
+import java.util.ArrayList;
 
 public class MockUserFactory {
 
@@ -43,13 +46,13 @@ public class MockUserFactory {
                 null,
                 null,
                 null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
+                true,
+                Permission.ROLE_USER,
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>()
         );
     }
 
@@ -61,13 +64,13 @@ public class MockUserFactory {
                 "profilePhoto",
                 null,
                 null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
+                true,
+                Permission.ROLE_USER,
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>(),
+                new ArrayList<>()
         );
     }
 

--- a/src/test/java/org/ahpuh/surf/unit/ControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/ControllerTest.java
@@ -1,6 +1,8 @@
 package org.ahpuh.surf.unit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.ahpuh.surf.category.controller.CategoryController;
+import org.ahpuh.surf.category.service.CategoryService;
 import org.ahpuh.surf.config.JwtConfig;
 import org.ahpuh.surf.user.controller.UserController;
 import org.ahpuh.surf.user.service.UserService;
@@ -15,11 +17,17 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureRestDocs
 @Import(JwtConfig.class)
 @ActiveProfiles("test")
-@WebMvcTest(UserController.class)
+@WebMvcTest({
+        UserController.class,
+        CategoryController.class
+})
 public abstract class ControllerTest {
 
     @MockBean
     protected UserService userService;
+
+    @MockBean
+    protected CategoryService categoryService;
 
     @Autowired
     protected MockMvc mockMvc;

--- a/src/test/java/org/ahpuh/surf/unit/category/controller/CategoryControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/controller/CategoryControllerTest.java
@@ -1,0 +1,330 @@
+package org.ahpuh.surf.unit.category.controller;
+
+import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
+import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.ahpuh.surf.category.dto.response.AllCategoryByUserResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryCreateResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryDetailResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryUpdateResponseDto;
+import org.ahpuh.surf.jwt.JwtAuthenticationToken;
+import org.ahpuh.surf.unit.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.*;
+import static org.ahpuh.surf.common.factory.MockJwtFactory.createJwtToken;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CategoryControllerTest extends ControllerTest {
+
+    @DisplayName("로그인을 한 상태로")
+    @Nested
+    class AfterLogin {
+
+        private static final String TOKEN = "TestToken";
+
+        @BeforeEach
+        void setUp() {
+            final JwtAuthenticationToken authentication = createJwtToken(1L, "testEmail");
+            final SecurityContext securityContext = mock(SecurityContext.class);
+            SecurityContextHolder.setContext(securityContext);
+
+            given(securityContext.getAuthentication())
+                    .willReturn(authentication);
+        }
+
+        @DisplayName("카테고리를 생성할 수 있다.")
+        @Test
+        void testCreateCategory() throws Exception {
+            // Given
+            final CategoryCreateRequestDto request = createMockCategoryCreateRequestDto();
+            final CategoryCreateResponseDto response = createMockCategoryCreateResponseDto();
+
+            given(categoryService.createCategory(anyLong(), any(CategoryCreateRequestDto.class)))
+                    .willReturn(response);
+
+            // When
+            final ResultActions perform = mockMvc.perform(post("/api/v1/categories")
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            final String responseBody = perform.andExpect(status().isCreated())
+                    .andDo(print())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString();
+            verify(categoryService, times(1))
+                    .createCategory(anyLong(), any(CategoryCreateRequestDto.class));
+            assertThat(responseBody).isEqualTo(objectMapper.writeValueAsString(response));
+
+            perform.andDo(document("category/create",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                    ),
+                    requestFields(
+                            fieldWithPath("name").type(JsonFieldType.STRING).description("카테고리명"),
+                            fieldWithPath("colorCode").type(JsonFieldType.STRING).description("지정 색깔코드")
+                    ),
+                    responseHeaders(
+                            headerWithName(HttpHeaders.LOCATION).description("location")
+                    ),
+                    responseFields(
+                            fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("카테고리 id")
+                    )));
+        }
+
+        @DisplayName("카테고리를 수정할 수 있다.")
+        @Test
+        void testUpdateCategory() throws Exception {
+            // Given
+            final CategoryUpdateRequestDto request = createMockCategoryUpdateRequestDto();
+            final CategoryUpdateResponseDto response = createMockCategoryUpdateResponseDto();
+
+            given(categoryService.updateCategory(anyLong(), any(CategoryUpdateRequestDto.class)))
+                    .willReturn(response);
+
+            // When
+            final ResultActions perform = mockMvc.perform(put("/api/v1/categories/{categoryId}", 1L)
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            final String responseBody = perform.andExpect(status().isOk())
+                    .andDo(print())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString();
+            verify(categoryService, times(1))
+                    .updateCategory(anyLong(), any(CategoryUpdateRequestDto.class));
+            assertThat(responseBody).isEqualTo(objectMapper.writeValueAsString(response));
+
+            perform.andDo(document("category/update",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                    ),
+                    requestFields(
+                            fieldWithPath("name").type(JsonFieldType.STRING).description("카테고리명"),
+                            fieldWithPath("isPublic").type(JsonFieldType.BOOLEAN).description("카테고리 공개여부"),
+                            fieldWithPath("colorCode").type(JsonFieldType.STRING).description("지정 색깔코드")
+                    ),
+                    responseFields(
+                            fieldWithPath("categoryId").type(JsonFieldType.NUMBER).description("카테고리 id")
+                    )));
+        }
+
+        @DisplayName("카테고리를 삭제할 수 있다.")
+        @Test
+        void testDeleteCategory() throws Exception {
+            // When
+            final ResultActions perform = mockMvc.perform(delete("/api/v1/categories/{categoryId}", 1L)
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN));
+
+            // Then
+            perform.andExpect(status().isNoContent())
+                    .andDo(print());
+            verify(categoryService, times(1))
+                    .deleteCategory(anyLong());
+
+            perform.andDo(document("category/delete",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                    ),
+                    pathParameters(
+                            parameterWithName("categoryId").description("카테고리 id")
+                    )));
+        }
+
+        @DisplayName("내 모든 카테고리를 반환할 수 있다.")
+        @Test
+        void testFindAllCategoryByUser() throws Exception {
+            // Given
+            final AllCategoryByUserResponseDto response = createMockAllCategoryByUserResponseDto();
+            given(categoryService.findAllCategoryByUser(anyLong()))
+                    .willReturn(List.of(response, response));
+
+            // When
+            final ResultActions perform = mockMvc.perform(get("/api/v1/categories")
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN));
+
+            // Then
+            perform.andExpect(status().isOk())
+                    .andDo(print());
+            verify(categoryService, times(1))
+                    .findAllCategoryByUser(anyLong());
+
+            perform.andDo(document("category/findAll",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                    ),
+                    responseFields(
+                            fieldWithPath("[].categoryId").type(JsonFieldType.NUMBER).description("카테고리 id")
+                                    .optional(),
+                            fieldWithPath("[].name").type(JsonFieldType.STRING).description("카테고리명")
+                                    .optional(),
+                            fieldWithPath("[].isPublic").type(JsonFieldType.BOOLEAN).description("카테고리 공개여부")
+                                    .optional(),
+                            fieldWithPath("[].colorCode").type(JsonFieldType.STRING).description("지정 색깔코드")
+                                    .optional()
+                    )));
+        }
+
+        @DisplayName("해당 유저의 모든 카테고리 평균점수, 게시글 개수를 조회할 수 있다.")
+        @Test
+        void testGetCategoryDashboard() throws Exception {
+            // Given
+            final CategoryDetailResponseDto response = createMockCategoryDetailResponseDto();
+            given(categoryService.getCategoryDashboard(anyLong()))
+                    .willReturn(List.of(response, response));
+
+            // When
+            final ResultActions perform = mockMvc.perform(get("/api/v1/categories/dashboard")
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .param("userId", "1"));
+
+            // Then
+            perform.andExpect(status().isOk())
+                    .andDo(print());
+            verify(categoryService, times(1))
+                    .getCategoryDashboard(anyLong());
+
+            perform.andDo(document("category/getDashboardInfo",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                            headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                    ),
+                    requestParameters(
+                            parameterWithName("userId").description("유저 id")
+                    ),
+                    responseFields(
+                            fieldWithPath("[].categoryId").type(JsonFieldType.NUMBER).description("카테고리 id")
+                                    .optional(),
+                            fieldWithPath("[].name").type(JsonFieldType.STRING).description("카테고리명")
+                                    .optional(),
+                            fieldWithPath("[].isPublic").type(JsonFieldType.BOOLEAN).description("카테고리 공개여부")
+                                    .optional(),
+                            fieldWithPath("[].colorCode").type(JsonFieldType.STRING).description("지정 색깔코드")
+                                    .optional(),
+                            fieldWithPath("[].averageScore").type(JsonFieldType.NUMBER).description("해당 카테고리의 게시글 평균점수")
+                                    .optional(),
+                            fieldWithPath("[].postCount").type(JsonFieldType.NUMBER).description("해당 카테고리의 게시글 갯수")
+                                    .optional()
+                    )));
+        }
+    }
+
+    @DisplayName("비로그인 상태로")
+    @Nested
+    class NotLoginYet {
+
+        @DisplayName("카테고리를 생성할 수 없다.")
+        @Test
+        void testCreateCategory_Fail() throws Exception {
+            // Given
+            final CategoryCreateRequestDto request = createMockCategoryCreateRequestDto();
+
+            // When
+            final ResultActions perform = mockMvc.perform(post("/api/v1/categories")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            perform.andExpect(status().isForbidden())
+                    .andDo(print());
+            verify(categoryService, times(0))
+                    .createCategory(any(), any());
+        }
+
+        @DisplayName("카테고리를 수정할 수 없다.")
+        @Test
+        void testUpdateCategory_Fail() throws Exception {
+            // Given
+            final CategoryUpdateRequestDto request = createMockCategoryUpdateRequestDto();
+
+            // When
+            final ResultActions perform = mockMvc.perform(put("/api/v1/categories/{categoryId}", 1L)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            perform.andExpect(status().isForbidden())
+                    .andDo(print());
+            verify(categoryService, times(0))
+                    .updateCategory(any(), any());
+        }
+
+        @DisplayName("카테고리를 삭제할 수 없다.")
+        @Test
+        void testDeleteCategory_Fail() throws Exception {
+            // When
+            final ResultActions perform = mockMvc.perform(
+                    delete("/api/v1/categories/{categoryId}", 1L));
+
+            // Then
+            perform.andExpect(status().isForbidden())
+                    .andDo(print());
+            verify(categoryService, times(0))
+                    .deleteCategory(any());
+        }
+
+        @DisplayName("내 모든 카테고리를 반환할 수 없다.")
+        @Test
+        void testFindAllCategoryByUser_Fail() throws Exception {
+            // When
+            final ResultActions perform = mockMvc.perform(
+                    get("/api/v1/categories"));
+
+            // Then
+            perform.andExpect(status().isForbidden())
+                    .andDo(print());
+            verify(categoryService, times(0))
+                    .findAllCategoryByUser(any());
+        }
+
+        @DisplayName("해당 유저의 모든 카테고리 평균점수, 게시글 개수를 조회할 수 없다.")
+        @Test
+        void testGetCategoryDashboard_Fail() throws Exception {
+            // When
+            final ResultActions perform = mockMvc.perform(get("/api/v1/categories/dashboard")
+                    .param("userId", "1"));
+
+            // Then
+            perform.andExpect(status().isForbidden())
+                    .andDo(print());
+            verify(categoryService, times(0))
+                    .getCategoryDashboard(any());
+        }
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/category/controller/CategoryRequestValidationTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/controller/CategoryRequestValidationTest.java
@@ -1,0 +1,159 @@
+package org.ahpuh.surf.unit.category.controller;
+
+import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
+import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.ahpuh.surf.jwt.JwtAuthenticationToken;
+import org.ahpuh.surf.unit.ControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.ahpuh.surf.common.factory.MockJwtFactory.createJwtToken;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class CategoryRequestValidationTest extends ControllerTest {
+
+    private static final String TOKEN = "TestToken";
+
+    @BeforeEach
+    void setUp() {
+        final JwtAuthenticationToken authentication = createJwtToken(1L, "testEmail");
+        final SecurityContext securityContext = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
+
+        given(securityContext.getAuthentication())
+                .willReturn(authentication);
+    }
+
+    @DisplayName("CategoryCreateRequestDto @Valid")
+    @Nested
+    class CategoryCreateRequestDtoTest {
+
+        @DisplayName("카테고리 이름은 최소 1, 최대 30 글자이다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = "카테고리이름은최대30글자까지입니다.이것은31글자이구요..")
+        void categoryName_Fail(final String categoryName) throws Exception {
+            // Given
+            final CategoryCreateRequestDto request = new CategoryCreateRequestDto(categoryName, "#000000");
+
+            // When
+            final ResultActions perform = mockMvc.perform(post("/api/v1/categories")
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            perform.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        @DisplayName("카테고리 색깔코드는 16진수의 헥스 컬러코드이다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "#",
+                "#G00000",
+                "#GGGGGG",
+                "#0000000",
+                "000000",
+                "잘못된색깔코드"
+        })
+        void colorCode_Fail(final String colorCode) throws Exception {
+            // Given
+            final CategoryCreateRequestDto request = new CategoryCreateRequestDto("카테고리이름", colorCode);
+
+            // When
+            final ResultActions perform = mockMvc.perform(post("/api/v1/categories")
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            perform.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+    }
+
+    @DisplayName("CategoryUpdateRequestDto @Valid")
+    @Nested
+    class CategoryUpdateRequestDtoTest {
+
+        @DisplayName("카테고리 이름은 최소 1, 최대 30 글자이다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = "카테고리이름은최대30글자까지입니다.이것은31글자이구요..")
+        void categoryName_Fail(final String categoryName) throws Exception {
+            // Given
+            final CategoryUpdateRequestDto request = new CategoryUpdateRequestDto(categoryName, true, "#000000");
+
+            // When
+            final ResultActions perform = mockMvc.perform(put("/api/v1/categories/{categoryId}", 1L)
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            perform.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        @DisplayName("카테고리 공개여부는 null을 허용하지 않는다.")
+        @ParameterizedTest
+        @NullSource
+        void isPublic_Fail(final Boolean isPublic) throws Exception {
+            // Given
+            final CategoryUpdateRequestDto request = new CategoryUpdateRequestDto("카테고리이름", isPublic, "#000000");
+
+            // When
+            final ResultActions perform = mockMvc.perform(put("/api/v1/categories/{categoryId}", 1L)
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            perform.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        @DisplayName("카테고리 색깔코드는 16진수의 헥스 컬러코드이다.")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "#",
+                "#G00000",
+                "#GGGGGG",
+                "#0000000",
+                "000000",
+                "잘못된색깔코드"
+        })
+        void colorCode_Fail(final String colorCode) throws Exception {
+            // Given
+            final CategoryUpdateRequestDto request = new CategoryUpdateRequestDto("카테고리이름", true, colorCode);
+
+            // When
+            final ResultActions perform = mockMvc.perform(put("/api/v1/categories/{categoryId}", 1L)
+                    .header(HttpHeaders.AUTHORIZATION, TOKEN)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // Then
+            perform.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryRepositoryTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryRepositoryTest.java
@@ -1,0 +1,208 @@
+package org.ahpuh.surf.unit.category.domain;
+
+import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.category.domain.CategoryRepository;
+import org.ahpuh.surf.config.QuerydslConfig;
+import org.ahpuh.surf.post.domain.Post;
+import org.ahpuh.surf.post.domain.repository.PostRepository;
+import org.ahpuh.surf.user.domain.User;
+import org.ahpuh.surf.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
+import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Import(QuerydslConfig.class)
+@DataJpaTest
+public class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @DisplayName("save 메소드는")
+    @Nested
+    class SaveMethod {
+
+        @DisplayName("카테고리를 등록할 수 있다.")
+        @Test
+        void saveCategory_Success() {
+            // Given
+            final User user = createMockUser();
+            testEntityManager.persist(user);
+            final Category category = createMockCategory(user);
+
+            // When
+            categoryRepository.save(category);
+
+            // Then
+            final List<Category> categories = categoryRepository.findAll();
+            assertAll("카테고리 등록 테스트",
+                    () -> assertThat(categories.size()).isEqualTo(1),
+                    () -> assertThat(categories.get(0).getName()).isEqualTo("categoryName")
+            );
+        }
+
+        @DisplayName("카테고리를 등록하면 해당 유저와 연관관계가 매핑된다.")
+        @Test
+        void categoryUserMappingTest() {
+            // Given
+            final User user = createMockUser();
+            testEntityManager.persist(user);
+            final Category category = createMockCategory(user);
+
+            // When
+            categoryRepository.save(category);
+
+            // Then
+            final List<Category> categories = categoryRepository.findAll();
+            assertAll("연관관계 매핑 테스트",
+                    () -> assertThat(categories.size()).isEqualTo(1),
+                    () -> assertThat(categories.get(0).getUser()).isEqualTo(user)
+            );
+        }
+    }
+
+    @DisplayName("findById 메소드는")
+    @Nested
+    class FindByIdMethod {
+
+        @DisplayName("categoryId로 조회할 수 있다.")
+        @Test
+        void findById_Success() {
+            // Given
+            final User user = createMockUser();
+            testEntityManager.persist(user);
+            final Category category = createMockCategory(user);
+            final Long categoryId = testEntityManager.persist(category).getCategoryId();
+
+            // When
+            final Optional<Category> findedCategory = categoryRepository.findById(categoryId);
+
+            // Then
+            assertAll(
+                    () -> assertThat(findedCategory).isNotEmpty(),
+                    () -> assertThat(findedCategory.get()).isSameAs(category)
+            );
+        }
+
+        @DisplayName("존재하지 않는 id로 조회할 수 없다.")
+        @Test
+        void findById_Fail() {
+            // When
+            final Optional<Category> findedCategory = categoryRepository.findById(1L);
+
+            // Then
+            assertThat(findedCategory).isEmpty();
+        }
+    }
+
+    @DisplayName("findByUser 메소드는")
+    @Nested
+    class FindByUserMethod {
+
+        @DisplayName("해당 유저의 모든 카테고리를 조회할 수 있다.")
+        @Test
+        void findAllCategoryByUser() {
+            // Given
+            final User user = createMockUser();
+            testEntityManager.persist(user);
+            final Category category1 = Category.builder()
+                    .user(user)
+                    .name("category1")
+                    .colorCode("000000")
+                    .build();
+            final Category category2 = Category.builder()
+                    .user(user)
+                    .name("category2")
+                    .colorCode("000000")
+                    .build();
+            testEntityManager.persist(category1);
+            testEntityManager.persist(category2);
+
+            // When
+            final List<Category> allCategoryByUser = categoryRepository.findByUser(user);
+
+            // Then
+            assertAll(
+                    () -> assertThat(allCategoryByUser.size()).isEqualTo(2),
+                    () -> assertThat(allCategoryByUser.get(0).getName()).isEqualTo("category1"),
+                    () -> assertThat(allCategoryByUser.get(1).getName()).isEqualTo("category2")
+            );
+        }
+
+        @DisplayName("해당 유저의 카테고리가 없는 경우 빈 리스트를 반환한다.")
+        @Test
+        void findByUser_NoCategory_ReturnEmptyList() {
+            // Given
+            final User user = createMockUser();
+            testEntityManager.persist(user);
+
+            // When
+            final List<Category> allCategoryByUser = categoryRepository.findByUser(user);
+
+            // Then
+            assertThat(allCategoryByUser).isEqualTo(List.of());
+        }
+    }
+
+    @DisplayName("delete 메소드는")
+    @Nested
+    class DeleteMethod {
+
+        @DisplayName("카테고리가 삭제되고 orphanRemoval가 동작한다.")
+        @Test
+        void deleteAllMapping() {
+            // Given
+            final User user = userRepository.save(createMockUser());
+            final Category category = categoryRepository.save(createMockCategory(user));
+            postRepository.save(createMockPost(user, category));
+            postRepository.save(createMockPost(user, category));
+
+            testEntityManager.clear();
+
+            final List<User> allUser = userRepository.findAll();
+            final List<Category> allCategory = categoryRepository.findAll();
+            final List<Post> allPost = postRepository.findAll();
+
+            assertAll("user, category, post save 확인",
+                    () -> assertThat(allUser.size()).isEqualTo(1),
+                    () -> assertThat(allCategory.size()).isEqualTo(1),
+                    () -> assertThat(allPost.size()).isEqualTo(2)
+            );
+
+            // When
+            final Category categoryEntity = categoryRepository.getById(category.getCategoryId());
+            categoryRepository.delete(categoryEntity);
+            testEntityManager.flush();
+            testEntityManager.clear();
+
+            // Then
+            assertAll("category와 모든 post가 orphan remove",
+                    () -> assertThat(userRepository.findAll().size()).isEqualTo(1),
+                    () -> assertThat(categoryRepository.findAll().size()).isEqualTo(0),
+                    () -> assertThat(postRepository.findAll().size()).isEqualTo(0)
+            );
+        }
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
@@ -1,0 +1,32 @@
+package org.ahpuh.surf.unit.category.domain;
+
+import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class CategoryTest {
+
+    @DisplayName("카테고리 정보를 수정할 수 있다.")
+    @Test
+    void updateCategoryTest() {
+        // Given
+        final User user = createSavedUser();
+        final Category category = createMockCategory(user);
+
+        // When
+        category.update("update", false, "FFFFFF");
+
+        // Then
+        assertAll("카테고리 정보 수정 테스트",
+                () -> assertThat(category.getName()).isEqualTo("update"),
+                () -> assertThat(category.getIsPublic()).isFalse(),
+                () -> assertThat(category.getColorCode()).isEqualTo("FFFFFF")
+        );
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/service/CategoryServiceTest.java
@@ -1,0 +1,401 @@
+package org.ahpuh.surf.unit.category.service;
+
+import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.category.domain.CategoryConverter;
+import org.ahpuh.surf.category.domain.CategoryRepository;
+import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
+import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.ahpuh.surf.category.dto.response.AllCategoryByUserResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryCreateResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryDetailResponseDto;
+import org.ahpuh.surf.category.dto.response.CategoryUpdateResponseDto;
+import org.ahpuh.surf.category.service.CategoryService;
+import org.ahpuh.surf.common.exception.category.CategoryNotFoundException;
+import org.ahpuh.surf.common.exception.user.UserNotFoundException;
+import org.ahpuh.surf.post.domain.Post;
+import org.ahpuh.surf.post.domain.repository.PostRepository;
+import org.ahpuh.surf.user.domain.User;
+import org.ahpuh.surf.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class CategoryServiceTest {
+
+    @InjectMocks
+    private CategoryService categoryService;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private CategoryConverter categoryConverter;
+
+    @DisplayName("createCategory 메소드는")
+    @Nested
+    class CreateCategoryMethod {
+
+        @DisplayName("카테고리를 생성할 수 있다.")
+        @Test
+        void createCategory_Success() {
+            // Given
+            final User mockUser = mock(User.class);
+            final Category mockCategory = mock(Category.class);
+            final Long userId = 1L;
+            final CategoryCreateRequestDto requestDto = mock(CategoryCreateRequestDto.class);
+            given(userRepository.findById(userId))
+                    .willReturn(Optional.of(mockUser));
+            given(categoryConverter.toEntity(mockUser, requestDto))
+                    .willReturn(mockCategory);
+            given(categoryRepository.save(mockCategory))
+                    .willReturn(mockCategory);
+            given(mockCategory.getCategoryId())
+                    .willReturn(1L);
+
+            // When
+            final CategoryCreateResponseDto responseDto = categoryService.createCategory(userId, requestDto);
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryConverter, times(1))
+                    .toEntity(any(User.class), any(CategoryCreateRequestDto.class));
+            verify(categoryRepository, times(1))
+                    .save(any(Category.class));
+            assertThat(responseDto.getCategoryId()).isEqualTo(1L);
+        }
+
+        @DisplayName("존재하지 않는 유저 아이디가 입력되면 예외가 발생한다.")
+        @Test
+        void userNotFoundException() {
+            // Given
+            final CategoryCreateRequestDto requestDto = mock(CategoryCreateRequestDto.class);
+            given(userRepository.findById(anyLong()))
+                    .willReturn(Optional.empty());
+
+            // When
+            assertThatThrownBy(() -> categoryService.createCategory(1L, requestDto))
+                    .isInstanceOf(UserNotFoundException.class)
+                    .hasMessage("해당 유저를 찾을 수 없습니다.");
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryConverter, times(0))
+                    .toEntity(any(User.class), any(CategoryCreateRequestDto.class));
+            verify(categoryRepository, times(0))
+                    .save(any(Category.class));
+        }
+    }
+
+    @DisplayName("updateCategory 메소드는")
+    @Nested
+    class UpdateCategoryMethod {
+
+        @DisplayName("카테고리 이름, 색깔정보, 공개여부를 수정한다.")
+        @Test
+        void updateCategory_Success() {
+            // Given
+            final Category mockCategory = mock(Category.class);
+            final Long categoryId = 1L;
+            final CategoryUpdateRequestDto requestDto = mock(CategoryUpdateRequestDto.class);
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(mockCategory));
+
+            // When
+            final CategoryUpdateResponseDto responseDto = categoryService.updateCategory(categoryId, requestDto);
+
+            // Then
+            verify(categoryRepository, times(1))
+                    .findById(anyLong());
+            verify(mockCategory, times(1))
+                    .update(any(), anyBoolean(), any());
+            assertThat(responseDto.getCategoryId()).isEqualTo(1L);
+        }
+
+        @DisplayName("존재하지 않는 카테고리 아이디가 입력되면 예외가 발생한다.")
+        @Test
+        void categoryNotFoundException() {
+            // Given
+            final CategoryUpdateRequestDto requestDto = mock(CategoryUpdateRequestDto.class);
+            given(categoryRepository.findById(anyLong()))
+                    .willReturn(Optional.empty());
+
+            // When
+            assertThatThrownBy(() -> categoryService.updateCategory(1L, requestDto))
+                    .isInstanceOf(CategoryNotFoundException.class)
+                    .hasMessage("해당 카테고리를 찾을 수 없습니다.");
+
+            // Then
+            verify(categoryRepository, times(1))
+                    .findById(anyLong());
+        }
+    }
+
+    @DisplayName("deleteCategory 메소드는")
+    @Nested
+    class DeleteCategoryMethod {
+
+        @DisplayName("카테고리를 삭제한다.")
+        @Test
+        void deleteCategory_Success() {
+            // Given
+            final Category mockCategory = mock(Category.class);
+            final Long categoryId = 1L;
+            given(categoryRepository.findById(categoryId))
+                    .willReturn(Optional.of(mockCategory));
+
+            // When
+            categoryService.deleteCategory(categoryId);
+
+            // Then
+            verify(categoryRepository, times(1))
+                    .findById(categoryId);
+            verify(categoryRepository, times(1))
+                    .delete(any(Category.class));
+        }
+
+        @DisplayName("존재하지 않는 카테고리 아이디가 입력되면 예외가 발생한다.")
+        @Test
+        void categoryNotFoundException() {
+            // Given
+            given(categoryRepository.findById(anyLong()))
+                    .willReturn(Optional.empty());
+
+            // When
+            assertThatThrownBy(() -> categoryService.deleteCategory(1L))
+                    .isInstanceOf(CategoryNotFoundException.class)
+                    .hasMessage("해당 카테고리를 찾을 수 없습니다.");
+
+            // Then
+            verify(categoryRepository, times(1))
+                    .findById(anyLong());
+        }
+    }
+
+    @DisplayName("findAllCategoryByUser 메소드는")
+    @Nested
+    class FindAllCategoryByUserMethod {
+
+        @DisplayName("해당 유저의 모든 카테고리를 반환한다.")
+        @Test
+        void findAllCategoryByUser_Success() {
+            // Given
+            final User mockUser = mock(User.class);
+            final Category mockCategory1 = mock(Category.class);
+            final Category mockCategory2 = mock(Category.class);
+            final Long userId = 1L;
+            given(userRepository.findById(userId))
+                    .willReturn(Optional.of(mockUser));
+            given(categoryRepository.findByUser(mockUser))
+                    .willReturn(List.of(mockCategory1, mockCategory2));
+            given(categoryConverter.toCategoryResponseDto(any(Category.class)))
+                    .willReturn(mock(AllCategoryByUserResponseDto.class));
+
+            // When
+            categoryService.findAllCategoryByUser(userId);
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryRepository, times(1))
+                    .findByUser(any(User.class));
+            verify(categoryConverter, times(2))
+                    .toCategoryResponseDto(any(Category.class));
+        }
+
+        @DisplayName("해당 유저의 카테고리가 없을 경우 빈 배열을 반환한다.")
+        @Test
+        void noCategoryByUser_ReturnEmptyList() {
+            // Given
+            final User mockUser = mock(User.class);
+            final Long userId = 1L;
+            given(userRepository.findById(userId))
+                    .willReturn(Optional.of(mockUser));
+            given(categoryRepository.findByUser(mockUser))
+                    .willReturn(List.of());
+
+            // When
+            final List<AllCategoryByUserResponseDto> responseDtos = categoryService.findAllCategoryByUser(userId);
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryRepository, times(1))
+                    .findByUser(any(User.class));
+            verify(categoryConverter, times(0))
+                    .toCategoryResponseDto(any(Category.class));
+            assertThat(responseDtos).isEqualTo(List.of());
+        }
+
+        @DisplayName("존재하지 않는 유저 아이디가 입력되면 예외가 발생한다.")
+        @Test
+        void userNotFoundException() {
+            // Given
+            given(userRepository.findById(anyLong()))
+                    .willReturn(Optional.empty());
+
+            // When
+            assertThatThrownBy(() -> categoryService.findAllCategoryByUser(1L))
+                    .isInstanceOf(UserNotFoundException.class)
+                    .hasMessage("해당 유저를 찾을 수 없습니다.");
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryRepository, times(0))
+                    .findByUser(any(User.class));
+            verify(categoryConverter, times(0))
+                    .toCategoryResponseDto(any(Category.class));
+        }
+    }
+
+    @DisplayName("getCategoryDashboard 메소드는")
+    @Nested
+    class GetCategoryDashboardMethod {
+
+        @DisplayName("대시보드에 표시할 모든 카테고리의 게시글 평균점수와 개수를 반환한다.")
+        @Test
+        void getCategoryDashboard_Success() {
+            // Given
+            final User mockUser = mock(User.class);
+            final Category mockCategory = mock(Category.class);
+            final Post post = createMockPost(mockUser, mockCategory);
+            final Long userId = 1L;
+            given(userRepository.findById(userId))
+                    .willReturn(Optional.of(mockUser));
+            given(categoryRepository.findByUser(mockUser))
+                    .willReturn(List.of(mockCategory, mockCategory));
+            given(postRepository.findByCategory(any()))
+                    .willReturn(List.of(post));
+            given(categoryConverter.toCategoryDetailResponseDto(any(Category.class), anyInt()))
+                    .willReturn(mock(CategoryDetailResponseDto.class));
+
+            // When
+            categoryService.getCategoryDashboard(userId);
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryRepository, times(1))
+                    .findByUser(any(User.class));
+            verify(postRepository, times(2))
+                    .findByCategory(any(Category.class));
+            verify(categoryConverter, times(2))
+                    .toCategoryDetailResponseDto(any(), isA(Integer.class));
+        }
+
+        @DisplayName("해당 유저의 카테고리가 없을 경우 빈 배열을 반환한다.")
+        @Test
+        void noCategoryByUser_ReturnEmptyList() {
+            // Given
+            final User mockUser = mock(User.class);
+            final Long userId = 1L;
+            given(userRepository.findById(userId))
+                    .willReturn(Optional.of(mockUser));
+            given(categoryRepository.findByUser(mockUser))
+                    .willReturn(List.of());
+
+            // When
+            final List<CategoryDetailResponseDto> responseDtos = categoryService.getCategoryDashboard(userId);
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryRepository, times(1))
+                    .findByUser(any(User.class));
+            verify(categoryConverter, times(0))
+                    .toCategoryDetailResponseDto(any(Category.class), isA(Integer.class));
+            assertThat(responseDtos).isEqualTo(List.of());
+        }
+
+        @DisplayName("존재하지 않는 유저 아이디가 입력되면 예외가 발생한다.")
+        @Test
+        void userNotFoundException() {
+            // Given
+            given(userRepository.findById(anyLong()))
+                    .willReturn(Optional.empty());
+
+            // When
+            assertThatThrownBy(() -> categoryService.getCategoryDashboard(1L))
+                    .isInstanceOf(UserNotFoundException.class)
+                    .hasMessage("해당 유저를 찾을 수 없습니다.");
+
+            // Then
+            verify(userRepository, times(1))
+                    .findById(anyLong());
+            verify(categoryRepository, times(0))
+                    .findByUser(any());
+            verify(categoryConverter, times(0))
+                    .toCategoryDetailResponseDto(any(), isA(Integer.class));
+        }
+    }
+
+    @DisplayName("getAverageScore 메소드는")
+    @Nested
+    class GetAverageScoreMethod {
+
+        @DisplayName("카테고리의 모든 게시글의 평균점수를 반환한다.")
+        @Test
+        void getAverageScore() {
+            // Given
+            final User user = mock(User.class);
+            final Category category = mock(Category.class);
+            final Post post1 = new Post(user, category, null, null, 95);
+            final Post post2 = new Post(user, category, null, null, 85);
+            given(postRepository.findByCategory(any(Category.class)))
+                    .willReturn(List.of(post1, post2));
+
+            // When
+            final double average = postRepository.findByCategory(category)
+                    .stream()
+                    .mapToInt(Post::getScore)
+                    .average()
+                    .orElse(0);
+
+            // Then
+            assertThat(average).isEqualTo(90D);
+        }
+
+        @DisplayName("카테고리의 게시글이 없는 경우 0을 반환한다.")
+        @Test
+        void getAverageScore_NoPost_ReturnZero() {
+            // Given
+            given(postRepository.findByCategory(any(Category.class)))
+                    .willReturn(List.of());
+
+            // When
+            final double average = postRepository.findByCategory(mock(Category.class))
+                    .stream()
+                    .mapToInt(Post::getScore)
+                    .average()
+                    .orElse(0);
+
+            // Then
+            assertThat(average).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/user/controller/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/user/controller/UserControllerTest.java
@@ -228,6 +228,8 @@ public class UserControllerTest extends ControllerTest {
                     .delete(anyLong());
 
             perform.andDo(document("user/deleteUser",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
                     requestHeaders(
                             headerWithName(HttpHeaders.AUTHORIZATION).description("token")
                     )));

--- a/src/test/java/org/ahpuh/surf/unit/user/domain/UserRepositoryTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/user/domain/UserRepositoryTest.java
@@ -67,9 +67,12 @@ public class UserRepositoryTest {
         @Test
         void saveUserNullCheck() {
             assertAll("null check",
-                    () -> assertThrows(DataIntegrityViolationException.class, () -> userRepository.save(createMockUser(null))),
-                    () -> assertThrows(DataIntegrityViolationException.class, () -> userRepository.save(createMockUser("email", null, "name"))),
-                    () -> assertThrows(DataIntegrityViolationException.class, () -> userRepository.save(createMockUser("email", "pw", null)))
+                    () -> assertThrows(DataIntegrityViolationException.class,
+                            () -> userRepository.save(createMockUser(null))),
+                    () -> assertThrows(DataIntegrityViolationException.class,
+                            () -> userRepository.save(createMockUser("email", null, "name"))),
+                    () -> assertThrows(DataIntegrityViolationException.class,
+                            () -> userRepository.save(createMockUser("email", "pw", null)))
             );
         }
 
@@ -195,26 +198,17 @@ public class UserRepositoryTest {
             final List<Category> allCategory = categoryRepository.findAll();
             final List<Post> allPost = postRepository.findAll();
 
-            assertAll("user, category, post를 save하고 양방향 매핑 확인",
+            assertAll("user, category, post save 확인",
                     () -> assertThat(allUser.size()).isEqualTo(1),
-                    () -> assertThat(allUser.get(0).getCategories().size()).isEqualTo(1),
-                    () -> assertThat(allUser.get(0).getPosts().size()).isEqualTo(2),
                     () -> assertThat(allCategory.size()).isEqualTo(1),
-                    () -> assertThat(allCategory.get(0).getUser())
-                            .isInstanceOf(User.class)
-                            .hasFieldOrPropertyWithValue("userId", savedUser.getUserId()),
-                    () -> assertThat(allCategory.get(0).getPosts().size()).isEqualTo(2),
-                    () -> assertThat(allPost.size()).isEqualTo(2),
-                    () -> assertThat(allPost.get(0).getUser())
-                            .isInstanceOf(User.class)
-                            .hasFieldOrPropertyWithValue("userId", savedUser.getUserId()),
-                    () -> assertThat(allPost.get(0).getCategory()).isSameAs(allCategory.get(0))
+                    () -> assertThat(allPost.size()).isEqualTo(2)
             );
 
             // When
-            final User userEntity = userRepository.getById(1L);
+            final User userEntity = userRepository.getById(savedUser.getUserId());
             userRepository.delete(userEntity);
             testEntityManager.flush();
+            testEntityManager.clear();
 
             // Then
             assertAll("user와 연관된 category, post까지 orphan remove",

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -16,6 +16,9 @@ spring:
         use_sql_comments: true
 server:
   port: 8080
+  servlet:
+    encoding:
+      force-response: true
 jwt:
   header: Authorization
   issuer: ahpuh


### PR DESCRIPTION
## 📄 Description

- close : #94 

> Category 도메인에 대한 단위 테스트를 작성합니다.

## 📌 구현 내용

- [x] Entity Unit Test
- [x] Repository Layer Unit Test
- [x] Service Layer Unit Test
- [x] Controller Layer Unit Test
- [x] Controller @Valid Test

Response Body에 한글이 깨지는 문제가 있어서 test/resources/`application.yml` 파일에 UTF-8 설정 옵션을 추가했습니다.