### PR TITLE
S3 파일 업로드 파일 타입을 Enum으로 관리

### DIFF
--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -10,6 +10,7 @@ import org.ahpuh.surf.common.domain.BaseEntity;
 import org.ahpuh.surf.common.exception.EntityExceptionHandler;
 import org.ahpuh.surf.post.domain.like.Like;
 import org.ahpuh.surf.s3.FileStatus;
+import org.ahpuh.surf.s3.FileType;
 import org.ahpuh.surf.user.domain.User;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -76,19 +77,19 @@ public class Post extends BaseEntity {
         category.addPost(this);
     }
 
-    public void editPost(final Category category, final LocalDate selectedDate, final String content, final int score) {
+    public void updatePost(final Category category, final LocalDate selectedDate, final String content, final int score) {
         this.category = category;
         this.selectedDate = selectedDate;
         this.content = content;
         this.score = score;
     }
 
-    public Post editFile(final FileStatus fileStatus) {
-        if (fileStatus.fileType().equals("img")) {
+    public Post updateFile(final FileStatus fileStatus) {
+        if (fileStatus.fileType().equals(FileType.IMG)) {
             this.imageUrl = fileStatus.fileUrl();
             this.fileUrl = null;
         }
-        if (fileStatus.fileType().equals("file")) {
+        if (fileStatus.fileType().equals(FileType.FILE)) {
             this.fileUrl = fileStatus.fileUrl();
             this.imageUrl = null;
         }

--- a/src/main/java/org/ahpuh/surf/post/service/PostService.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostService.java
@@ -58,7 +58,7 @@ public class PostService {
 
         final Post post = postConverter.toEntity(user, category, request);
         if (fileStatus != null) {
-            post.editFile(fileStatus);
+            post.updateFile(fileStatus);
         }
         final Long postId = postRepository.save(post)
                 .getPostId();
@@ -80,9 +80,9 @@ public class PostService {
         final Category category = getCategoryById(request.getCategoryId());
         final Post post = getPostById(postId);
 
-        post.editPost(category, LocalDate.parse(request.getSelectedDate()), request.getContent(), request.getScore());
+        post.updatePost(category, LocalDate.parse(request.getSelectedDate()), request.getContent(), request.getScore());
         if (fileStatus != null) {
-            post.editFile(fileStatus);
+            post.updateFile(fileStatus);
         }
 
         return new PostUpdateResponseDto(postId);

--- a/src/main/java/org/ahpuh/surf/s3/FileStatus.java
+++ b/src/main/java/org/ahpuh/surf/s3/FileStatus.java
@@ -2,6 +2,6 @@ package org.ahpuh.surf.s3;
 
 public record FileStatus(
         String fileUrl,
-        String fileType
+        FileType fileType
 ) {
 }

--- a/src/main/java/org/ahpuh/surf/s3/FileType.java
+++ b/src/main/java/org/ahpuh/surf/s3/FileType.java
@@ -1,0 +1,12 @@
+package org.ahpuh.surf.s3;
+
+public enum FileType {
+    IMG("img"),
+    FILE("file");
+
+    private final String fileType;
+
+    FileType(final String fileType) {
+        this.fileType = fileType;
+    }
+}

--- a/src/main/java/org/ahpuh/surf/s3/MockS3Service.java
+++ b/src/main/java/org/ahpuh/surf/s3/MockS3Service.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
@@ -21,23 +20,23 @@ public class MockS3Service implements S3Service {
     private static final List<String> PERMISSION_FILE_EXTENSIONS = List.of("doc", "docx", "xls", "xlsx", "hwp", "pdf", "txt", "md", "ppt", "pptx", "key");
 
     @Transactional
-    public String uploadUserImage(final MultipartFile profilePhoto) throws IOException {
+    public String uploadUserImage(final MultipartFile profilePhoto) {
         return profilePhoto.isEmpty()
                 ? null
                 : uploadImg(profilePhoto);
     }
 
     @Transactional
-    public FileStatus uploadPostFile(final MultipartFile file) throws IOException {
+    public FileStatus uploadPostFile(final MultipartFile file) {
         if (!file.isEmpty()) {
             String fileUrl = uploadFile(file);
             if (fileUrl != null) {
-                return new FileStatus(fileUrl, "file");
+                return new FileStatus(fileUrl, FileType.FILE);
             }
 
             fileUrl = uploadImg(file);
             if (fileUrl != null) {
-                return new FileStatus(fileUrl, "img");
+                return new FileStatus(fileUrl, FileType.IMG);
             }
         }
         return null;

--- a/src/main/java/org/ahpuh/surf/s3/S3ServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/s3/S3ServiceImpl.java
@@ -65,12 +65,12 @@ public class S3ServiceImpl implements S3Service {
         if (file.isEmpty()) {
             String fileUrl = uploadFile(file);
             if (fileUrl != null) {
-                return new FileStatus(fileUrl, "file");
+                return new FileStatus(fileUrl, FileType.FILE);
             }
 
             fileUrl = uploadImg(file);
             if (fileUrl != null) {
-                return new FileStatus(fileUrl, "img");
+                return new FileStatus(fileUrl, FileType.IMG);
             }
         }
         return null;


### PR DESCRIPTION
## 📄 Description

- close : #99 

> S3 파일 업로드시 파일 타입을 Enum으로 관리하도록 수정합니다.

## 📌 구현 내용

- [x] FileType Enum 클래스 추가(IMG, FILE)
- [x] FileType 적용
