### PR TITLE
리팩토링 - @SuperBuilder 삭제, Checked exception 추가

### DIFF
--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -4,8 +4,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import org.ahpuh.surf.common.domain.BaseEntity;
+import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
 import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.user.domain.User;
 import org.hibernate.annotations.Formula;
@@ -16,13 +16,12 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity
-@Table(name = "categories")
 @Getter
-@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE categories SET is_deleted = true WHERE category_id = ?")
 @Where(clause = "is_deleted = false")
+@Entity
+@Table(name = "categories")
 public class Category extends BaseEntity {
 
     @Id
@@ -34,8 +33,7 @@ public class Category extends BaseEntity {
     private String name;
 
     @Column(name = "is_public", nullable = false)
-    @Builder.Default
-    private Boolean isPublic = true;
+    private Boolean isPublic;
 
     @Column(name = "color_code")
     private String colorCode;
@@ -45,8 +43,7 @@ public class Category extends BaseEntity {
     private User user;
 
     @OneToMany(mappedBy = "category", fetch = FetchType.LAZY, orphanRemoval = true)
-    @Builder.Default
-    private List<Post> posts = new ArrayList<>();
+    private List<Post> posts;
 
     @Formula("(select count(1) from posts p where p.category_id = category_id and p.is_deleted = false)")
     private int postCount;
@@ -56,11 +53,9 @@ public class Category extends BaseEntity {
         this.user = user;
         this.name = name;
         this.colorCode = colorCode;
+        isPublic = true;
+        posts = new ArrayList<>();
         user.addCategory(this);
-    }
-
-    public void addPost(final Post post) {
-        posts.add(post);
     }
 
     public void update(final String name, final boolean isPublic, final String colorCode) {
@@ -69,4 +64,7 @@ public class Category extends BaseEntity {
         this.colorCode = colorCode;
     }
 
+    public void addPost(final Post post) {
+        posts.add(post);
+    }
 }

--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -65,6 +65,9 @@ public class Category extends BaseEntity {
     }
 
     public void addPost(final Post post) {
+        if (posts.contains(post)) {
+            throw new DuplicatedPostException();
+        }
         posts.add(post);
     }
 }

--- a/src/main/java/org/ahpuh/surf/common/domain/BaseEntity.java
+++ b/src/main/java/org/ahpuh/surf/common/domain/BaseEntity.java
@@ -1,7 +1,6 @@
 package org.ahpuh.surf.common.domain;
 
-import lombok.*;
-import lombok.experimental.SuperBuilder;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -9,14 +8,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.PrePersist;
 import java.time.LocalDateTime;
 
 @Getter
-@MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-@SuperBuilder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@MappedSuperclass
 public abstract class BaseEntity {
 
     @CreatedDate
@@ -28,11 +25,10 @@ public abstract class BaseEntity {
     private LocalDateTime updatedAt;
 
     @Column(name = "is_deleted", columnDefinition = "boolean default false")
-    @Builder.Default
-    private Boolean isDeleted = false;
+    private Boolean isDeleted;
 
-    public void delete() {
-        this.isDeleted = true;
+    @PrePersist
+    private void setIsDeleted() {
+        isDeleted = false;
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/common/exception/ExceptionType.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/ExceptionType.java
@@ -14,12 +14,16 @@ public enum ExceptionType {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "잘못된 비밀번호입니다."),
     DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+    DUPLICATED_FOLLOWING(HttpStatus.BAD_REQUEST, "이미 팔로우 한 사용자입니다."),
 
     // CATEGORY
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
+    DUPLICATED_CATEGORY(HttpStatus.BAD_REQUEST, "이미 등록된 카테고리입니다."),
 
     // POST
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
+    DUPLICATED_POST(HttpStatus.BAD_REQUEST, "이미 등록된 게시글입니다."),
+    DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 게시글입니다."),
     FAVORITE_INVALID_USER(HttpStatus.BAD_REQUEST, "즐겨찾기를 등록 또는 취소할 수 없습니다.(내 게시글만 등록 가능)"),
     FAVORITE_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "이미 실행된 요청입니다.");
 

--- a/src/main/java/org/ahpuh/surf/common/exception/category/DuplicatedCategoryException.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/category/DuplicatedCategoryException.java
@@ -1,0 +1,11 @@
+package org.ahpuh.surf.common.exception.category;
+
+import org.ahpuh.surf.common.exception.ApplicationException;
+import org.ahpuh.surf.common.exception.ExceptionType;
+
+public class DuplicatedCategoryException extends ApplicationException {
+
+    public DuplicatedCategoryException() {
+        super(ExceptionType.DUPLICATED_CATEGORY.getHttpStatus(), ExceptionType.DUPLICATED_CATEGORY.getDetail());
+    }
+}

--- a/src/main/java/org/ahpuh/surf/common/exception/post/DuplicatedLikeException.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/post/DuplicatedLikeException.java
@@ -1,0 +1,11 @@
+package org.ahpuh.surf.common.exception.post;
+
+import org.ahpuh.surf.common.exception.ApplicationException;
+import org.ahpuh.surf.common.exception.ExceptionType;
+
+public class DuplicatedLikeException extends ApplicationException {
+
+    public DuplicatedLikeException() {
+        super(ExceptionType.DUPLICATED_LIKE.getHttpStatus(), ExceptionType.DUPLICATED_LIKE.getDetail());
+    }
+}

--- a/src/main/java/org/ahpuh/surf/common/exception/post/DuplicatedPostException.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/post/DuplicatedPostException.java
@@ -1,0 +1,11 @@
+package org.ahpuh.surf.common.exception.post;
+
+import org.ahpuh.surf.common.exception.ApplicationException;
+import org.ahpuh.surf.common.exception.ExceptionType;
+
+public class DuplicatedPostException extends ApplicationException {
+
+    public DuplicatedPostException() {
+        super(ExceptionType.DUPLICATED_POST.getHttpStatus(), ExceptionType.DUPLICATED_POST.getDetail());
+    }
+}

--- a/src/main/java/org/ahpuh/surf/common/exception/user/DuplicatedFollowingException.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/user/DuplicatedFollowingException.java
@@ -1,0 +1,11 @@
+package org.ahpuh.surf.common.exception.user;
+
+import org.ahpuh.surf.common.exception.ApplicationException;
+import org.ahpuh.surf.common.exception.ExceptionType;
+
+public class DuplicatedFollowingException extends ApplicationException {
+
+    public DuplicatedFollowingException() {
+        super(ExceptionType.DUPLICATED_FOLLOWING.getHttpStatus(), ExceptionType.DUPLICATED_FOLLOWING.getDetail());
+    }
+}

--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -100,6 +100,9 @@ public class Post extends BaseEntity {
     }
 
     public void addLike(final Like like) {
+        if (likes.contains(like)) {
+            throw new DuplicatedLikeException();
+        }
         likes.add(like);
     }
 }

--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -4,9 +4,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import org.ahpuh.surf.category.domain.Category;
 import org.ahpuh.surf.common.domain.BaseEntity;
+import org.ahpuh.surf.common.exception.post.DuplicatedLikeException;
 import org.ahpuh.surf.common.exception.post.FavoriteInvalidUserException;
 import org.ahpuh.surf.post.domain.like.Like;
 import org.ahpuh.surf.s3.FileStatus;
@@ -22,7 +22,6 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SuperBuilder
 @SQLDelete(sql = "UPDATE posts SET is_deleted = true WHERE post_id = ?")
 @Where(clause = "is_deleted = false")
 @Entity
@@ -58,12 +57,10 @@ public class Post extends BaseEntity {
     private String imageUrl;
 
     @Column(name = "favorite")
-    @Builder.Default
-    private Boolean favorite = false;
+    private Boolean favorite;
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, orphanRemoval = true)
-    @Builder.Default
-    private List<Like> likes = new ArrayList<>();
+    private List<Like> likes;
 
     @Builder
     public Post(final User user, final Category category, final LocalDate selectedDate, final String content, final int score) {
@@ -73,6 +70,7 @@ public class Post extends BaseEntity {
         this.content = content;
         this.score = score;
         favorite = false;
+        likes = new ArrayList<>();
         user.addPost(this);
         category.addPost(this);
     }
@@ -104,5 +102,4 @@ public class Post extends BaseEntity {
     public void addLike(final Like like) {
         likes.add(like);
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/post/domain/like/Like.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/like/Like.java
@@ -1,11 +1,16 @@
 package org.ahpuh.surf.post.domain.like;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.user.domain.User;
 
 import javax.persistence.*;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(
         name = "likes",
@@ -15,9 +20,6 @@ import javax.persistence.*;
                 )
         }
 )
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Like {
 
     @Id
@@ -39,5 +41,4 @@ public class Like {
         this.post = post;
         post.addLike(this);
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -1,9 +1,11 @@
 package org.ahpuh.surf.user.domain;
 
 import lombok.*;
-import lombok.experimental.SuperBuilder;
 import org.ahpuh.surf.category.domain.Category;
 import org.ahpuh.surf.common.domain.BaseEntity;
+import org.ahpuh.surf.common.exception.category.DuplicatedCategoryException;
+import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
+import org.ahpuh.surf.common.exception.user.DuplicatedFollowingException;
 import org.ahpuh.surf.common.exception.user.InvalidPasswordException;
 import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.post.domain.like.Like;
@@ -17,14 +19,13 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity
-@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SuperBuilder
 @SQLDelete(sql = "UPDATE users SET is_deleted = 1 WHERE user_id = ?")
 @Where(clause = "is_deleted = false")
+@Entity
+@Table(name = "users")
 public class User extends BaseEntity {
 
     @Id
@@ -51,39 +52,39 @@ public class User extends BaseEntity {
     private String aboutMe;
 
     @Column(name = "account_public", columnDefinition = "boolean default true")
-    @Builder.Default
-    private Boolean accountPublic = true;
+    private Boolean accountPublic;
 
     @Column(name = "permission")
     @Enumerated(value = EnumType.STRING)
-    @Builder.Default
-    private Permission permission = Permission.ROLE_USER;
+    private Permission permission;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
-    @Builder.Default
-    private List<Category> categories = new ArrayList<>();
+    private List<Category> categories;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
-    @Builder.Default
-    private List<Post> posts = new ArrayList<>();
+    private List<Post> posts;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
-    @Builder.Default
-    private List<Follow> following = new ArrayList<>(); // 내가 팔로잉한
+    private List<Follow> following; // 내가 팔로잉한
 
     @OneToMany(mappedBy = "followedUser", fetch = FetchType.LAZY, orphanRemoval = true)
-    @Builder.Default
-    private List<Follow> followers = new ArrayList<>(); // 나를 팔로우한
+    private List<Follow> followers; // 나를 팔로우한
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
-    @Builder.Default
-    private List<Like> likes = new ArrayList<>();
+    private List<Like> likes;
 
     @Builder
     public User(final String email, final String password, final String userName) {
         this.email = email;
         this.password = password;
         this.userName = userName;
+        accountPublic = true;
+        permission = Permission.ROLE_USER;
+        categories = new ArrayList<>();
+        posts = new ArrayList<>();
+        following = new ArrayList<>();
+        followers = new ArrayList<>();
+        likes = new ArrayList<>();
     }
 
     public boolean checkPassword(final PasswordEncoder passwordEncoder, final String credentials) {
@@ -129,5 +130,4 @@ public class User extends BaseEntity {
     public void addFollowers(final Follow follower) {
         followers.add(follower);
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -116,18 +116,30 @@ public class User extends BaseEntity {
     }
 
     public void addCategory(final Category category) {
+        if (categories.contains(category)) {
+            throw new DuplicatedCategoryException();
+        }
         categories.add(category);
     }
 
     public void addPost(final Post post) {
+        if (posts.contains(post)) {
+            throw new DuplicatedPostException();
+        }
         posts.add(post);
     }
 
     public void addFollowing(final Follow followingUser) {
+        if (following.contains(followingUser)) {
+            throw new DuplicatedFollowingException();
+        }
         following.add(followingUser);
     }
 
     public void addFollowers(final Follow follower) {
+        if (followers.contains(follower)) {
+            throw new DuplicatedFollowingException();
+        }
         followers.add(follower);
     }
 }

--- a/src/main/java/org/ahpuh/surf/user/domain/follow/Follow.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/follow/Follow.java
@@ -1,10 +1,15 @@
 package org.ahpuh.surf.user.domain.follow;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.ahpuh.surf.user.domain.User;
 
 import javax.persistence.*;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(
         name = "follow",
@@ -14,9 +19,6 @@ import javax.persistence.*;
                 )
         }
 )
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Follow {
 
     @Id
@@ -39,5 +41,4 @@ public class Follow {
         user.addFollowing(this);
         followedUser.addFollowers(this);
     }
-
 }

--- a/src/test/java/org/ahpuh/surf/integration/category/controller/CategoryControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/category/controller/CategoryControllerTest.java
@@ -68,6 +68,8 @@ class CategoryControllerTest {
                 .colorCode("#e7f5ff")
                 .build());
         postRepository.save(Post.builder()
+                .user(user)
+                .category(category)
                 .content("post1")
                 .selectedDate(LocalDate.now())
                 .score(88).build());
@@ -139,5 +141,4 @@ class CategoryControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
     }
-
 }

--- a/src/test/java/org/ahpuh/surf/integration/category/service/CategoryServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/category/service/CategoryServiceTest.java
@@ -162,6 +162,7 @@ class CategoryServiceTest {
 
         // when
         final List<CategoryDetailResponseDto> categories = categoryService.getCategoryDashboard(id);
+        entityManager.flush();
         entityManager.clear();
 
         // then

--- a/src/test/java/org/ahpuh/surf/unit/post/service/PostServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/service/PostServiceTest.java
@@ -1,36 +1,18 @@
 package org.ahpuh.surf.unit.post.service;
 
-import org.ahpuh.surf.category.domain.Category;
 import org.ahpuh.surf.category.domain.CategoryRepository;
-import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.post.domain.PostConverter;
 import org.ahpuh.surf.post.domain.repository.PostRepository;
-import org.ahpuh.surf.post.dto.request.PostRequestDto;
 import org.ahpuh.surf.post.service.PostService;
-import org.ahpuh.surf.user.domain.User;
+import org.ahpuh.surf.s3.S3Service;
 import org.ahpuh.surf.user.domain.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDate;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
-class PostServiceTest {
-
-    @Mock
-    private PostConverter postConverter;
+public class PostServiceTest {
 
     @Mock
     private PostRepository postRepository;
@@ -41,85 +23,12 @@ class PostServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private PostConverter postConverter;
+
     @InjectMocks
     private PostService postService;
-
-    private Post post;
-    private Category category;
-    private User user;
-
-    private Long postId;
-    private Long categoryId;
-    private String selectedDate;
-    private String content;
-    private int score;
-
-    @BeforeEach
-    void setUp() {
-        user = User.builder()
-                .userName("ah-puh")
-                .email("aaa@gmail.com")
-                .password("pswd")
-                .build();
-
-        Mockito.lenient().when(userRepository.findById(1L))
-                .thenReturn(Optional.of(user));
-
-        postId = 1L;
-        categoryId = 1L;
-        selectedDate = "2021-12-06";
-        content = "어푸";
-        score = 100;
-
-        category = Category.builder().build();
-        post = Post.builder()
-                .category(category)
-                .selectedDate(LocalDate.parse(selectedDate))
-                .content(content)
-                .score(score)
-                .build();
-
-        Mockito.lenient().when(categoryRepository.findById(categoryId))
-                .thenReturn(Optional.of(category));
-    }
-
-    @Test
-    @DisplayName("post 생성")
-    void create() {
-        // given
-        final Long userId = 1L;
-        final PostRequestDto request = PostRequestDto.builder()
-                .categoryId(categoryId)
-                .selectedDate(selectedDate)
-                .content(content)
-                .score(score)
-                .build();
-        when(postConverter.toEntity(any(), any(), any()))
-                .thenReturn(post);
-        when(postRepository.save(any(Post.class)))
-                .thenReturn(post);
-
-        // when
-        postService.create(userId, request, null);
-
-        // then
-        assertAll(
-                () -> verify(postRepository, times(1)).save(any(Post.class))
-        );
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 id로 post 조회")
-    void throwException_getPostById() {
-        // given
-        final Long invalidPostId = -1L;
-        when(postRepository.findById(invalidPostId))
-                .thenReturn(Optional.empty());
-
-        // when, then
-        assertThatThrownBy(() -> postService.readOne(1L, invalidPostId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Post with given id not found. Invalid id is " + invalidPostId);
-    }
-
 }


### PR DESCRIPTION
## 📄 Description

- close : #105 

> `@SuperBuilder`를 적용했던 부분들을 `@Builder`가 적용되도록 수정합니다.
> 연관관계 매핑시 예외 사항을 추가합니다.

## 📌 구현 내용

- [x] `@SuperBuilder` 삭제
- [x] 예외 추가

## ✅ PR 포인트
- @SuperBuilder 를 사용한 이유는 @Builder.Default 를 사용하기 위함이었는데,  
  SuperBuilder 때문에 생성자에 붙인 @Builder가 제대로 동작을 안하는 오류를 발견했습니다.  
  SuperBuilder를 삭제하고 생성자에서 필드값 초기화를 진행하도록 수정했습니다.
