### PR TITLE
Follow 엔티티 필드명 수정 (source, target)

### DIFF
--- a/src/main/java/org/ahpuh/surf/post/domain/PostConverter.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/PostConverter.java
@@ -140,7 +140,7 @@ public class PostConverter {
         if (post.getUser()
                 .getFollowers()
                 .stream()
-                .anyMatch(follow -> follow.getUser().equals(me))) {
+                .anyMatch(follow -> follow.getSource().equals(me))) {
             recentPostDto.checkFollowed();
         }
         return recentPostDto;

--- a/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepositoryImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepositoryImpl.java
@@ -36,9 +36,9 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                         post.createdAt.as("createdAt")
                 ))
                 .from(post)
-                .leftJoin(follow).on(follow.user.userId.eq(userId))
+                .leftJoin(follow).on(follow.source.userId.eq(userId))
                 .where(
-                        follow.followedUser.userId.eq(post.user.userId),
+                        follow.target.userId.eq(post.user.userId),
                         post.isDeleted.eq(false)
                 )
                 .groupBy(post.postId, follow.followId)
@@ -65,9 +65,9 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                         post.createdAt.as("createdAt")
                 ))
                 .from(post)
-                .leftJoin(follow).on(follow.user.userId.eq(userId))
+                .leftJoin(follow).on(follow.source.userId.eq(userId))
                 .where(
-                        follow.followedUser.userId.eq(post.user.userId),
+                        follow.target.userId.eq(post.user.userId),
                         post.isDeleted.eq(false),
                         post.selectedDate.loe(selectedDate),
                         post.createdAt.before(createdAt)

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -64,10 +64,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Post> posts;
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "source", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Follow> following; // 내가 팔로잉한
 
-    @OneToMany(mappedBy = "followedUser", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "target", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Follow> followers; // 나를 팔로우한
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)

--- a/src/main/java/org/ahpuh/surf/user/domain/follow/Follow.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/follow/Follow.java
@@ -28,17 +28,17 @@ public class Follow {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "user_id")
-    private User user;
+    private User source;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id", referencedColumnName = "user_id")
-    private User followedUser;
+    private User target;
 
     @Builder
-    public Follow(final User user, final User followedUser) {
-        this.user = user;
-        this.followedUser = followedUser;
-        user.addFollowing(this);
-        followedUser.addFollowers(this);
+    public Follow(final User source, final User target) {
+        this.source = source;
+        this.target = target;
+        source.addFollowing(this);
+        target.addFollowers(this);
     }
 }

--- a/src/main/java/org/ahpuh/surf/user/domain/follow/FollowConverter.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/follow/FollowConverter.java
@@ -7,10 +7,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class FollowConverter {
 
-    public Follow toEntity(final User user, final User followedUser) {
+    public Follow toEntity(final User source, final User target) {
         return Follow.builder()
-                .user(user)
-                .followedUser(followedUser)
+                .source(source)
+                .target(target)
                 .build();
     }
 
@@ -21,5 +21,4 @@ public class FollowConverter {
                 .profilePhotoUrl(user.getProfilePhotoUrl())
                 .build();
     }
-
 }

--- a/src/main/java/org/ahpuh/surf/user/domain/follow/FollowRepository.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/follow/FollowRepository.java
@@ -8,14 +8,14 @@ import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
-    Optional<Follow> findByUserAndFollowedUser(User me, User followedUser);
+    Optional<Follow> findBySourceAndTarget(User source, User target);
 
-    List<Follow> findByUser(User user);
+    List<Follow> findBySource(User source);
 
-    List<Follow> findByFollowedUser(User user);
+    List<Follow> findByTarget(User target);
 
-    long countByUser(User user);
+    long countBySource(User source);
 
-    long countByFollowedUser(User user);
+    long countByTarget(User target);
 
 }

--- a/src/main/java/org/ahpuh/surf/user/service/FollowService.java
+++ b/src/main/java/org/ahpuh/surf/user/service/FollowService.java
@@ -26,37 +26,37 @@ public class FollowService {
     private final FollowConverter followConverter;
 
     @Transactional
-    public FollowResponseDto follow(final Long userId, final Long followUserId) {
-        final User user = userRepository.findById(userId)
+    public FollowResponseDto follow(final Long userId, final Long targetId) {
+        final User source = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFound(userId));
-        final User followedUser = userRepository.findById(followUserId)
-                .orElseThrow(() -> UserNotFound(followUserId));
+        final User target = userRepository.findById(targetId)
+                .orElseThrow(() -> UserNotFound(targetId));
 
-        final Long followId = followRepository.save(followConverter.toEntity(user, followedUser))
+        final Long followId = followRepository.save(followConverter.toEntity(source, target))
                 .getFollowId();
 
         return new FollowResponseDto(followId);
     }
 
     @Transactional
-    public void unfollow(final Long myId, final Long userId) {
-        final User me = userRepository.findById(myId)
-                .orElseThrow(() -> UserNotFound(myId));
-        final User followedUser = userRepository.findById(userId)
+    public void unfollow(final Long userId, final Long targetId) {
+        final User source = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFound(userId));
+        final User target = userRepository.findById(targetId)
+                .orElseThrow(() -> UserNotFound(targetId));
 
-        final Follow followEntity = followRepository.findByUserAndFollowedUser(me, followedUser)
+        final Follow followEntity = followRepository.findBySourceAndTarget(source, target)
                 .orElseThrow(EntityExceptionHandler::FollowNotFound);
 
         followRepository.delete(followEntity);
     }
 
-    public List<FollowUserResponseDto> findFollowerList(final Long userId) {
-        final User userEntity = userRepository.findById(userId)
-                .orElseThrow(() -> UserNotFound(userId));
-        return followRepository.findByFollowedUser(userEntity)
+    public List<FollowUserResponseDto> findFollowerList(final Long targetId) {
+        final User userEntity = userRepository.findById(targetId)
+                .orElseThrow(() -> UserNotFound(targetId));
+        return followRepository.findByTarget(userEntity)
                 .stream()
-                .map(Follow::getUser)
+                .map(Follow::getSource)
                 .map(followConverter::toFollowUserDto)
                 .toList();
     }
@@ -64,9 +64,9 @@ public class FollowService {
     public List<FollowUserResponseDto> findFollowingList(final Long userId) {
         final User userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> UserNotFound(userId));
-        return followRepository.findByUser(userEntity)
+        return followRepository.findBySource(userEntity)
                 .stream()
-                .map(Follow::getFollowedUser)
+                .map(Follow::getTarget)
                 .map(followConverter::toFollowUserDto)
                 .toList();
     }

--- a/src/main/java/org/ahpuh/surf/user/service/UserService.java
+++ b/src/main/java/org/ahpuh/surf/user/service/UserService.java
@@ -64,8 +64,8 @@ public class UserService {
 
     public UserFindInfoResponseDto findUser(final Long userId) {
         final User userEntity = getUser(userId);
-        final long followingCount = followRepository.countByUser(userEntity);
-        final long followerCount = followRepository.countByFollowedUser(userEntity);
+        final long followingCount = followRepository.countBySource(userEntity);
+        final long followerCount = followRepository.countByTarget(userEntity);
         return userConverter.toUserFindInfoResponseDto(userEntity, followingCount, followerCount);
     }
 

--- a/src/test/java/org/ahpuh/surf/integration/post/repository/PostQueryDslTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/post/repository/PostQueryDslTest.java
@@ -115,12 +115,12 @@ class PostQueryDslTest {
 
         // Following : user1 -> user2, user3
         followRepository.save(Follow.builder()
-                .user(user1)
-                .followedUser(user2)
+                .source(user1)
+                .target(user2)
                 .build());
         followRepository.save(Follow.builder()
-                .user(user1)
-                .followedUser(user3)
+                .source(user1)
+                .target(user3)
                 .build());
     }
 
@@ -145,8 +145,8 @@ class PostQueryDslTest {
                         post.createdAt.as("createdAt")
                 ))
                 .from(post)
-                .leftJoin(follow).on(follow.user.userId.eq(userId1))
-                .where(follow.followedUser.userId.eq(post.user.userId), post.isDeleted.eq(false))
+                .leftJoin(follow).on(follow.source.userId.eq(userId1))
+                .where(follow.target.userId.eq(post.user.userId), post.isDeleted.eq(false))
                 .groupBy(post.postId, follow.followId)
                 .orderBy(post.selectedDate.desc(), post.createdAt.desc())
                 .limit(page.getPageSize())

--- a/src/test/java/org/ahpuh/surf/integration/user/controller/FollowControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/user/controller/FollowControllerTest.java
@@ -93,8 +93,8 @@ class FollowControllerTest {
         final List<Follow> allFollow = followRepository.findAll();
         assertAll("afterFollow",
                 () -> assertThat(allFollow.size()).isEqualTo(1),
-                () -> assertThat(allFollow.get(0).getUser()).isEqualTo(user1),
-                () -> assertThat(allFollow.get(0).getFollowedUser()).isEqualTo(user2)
+                () -> assertThat(allFollow.get(0).getSource()).isEqualTo(user1),
+                () -> assertThat(allFollow.get(0).getTarget()).isEqualTo(user2)
         );
     }
 
@@ -104,15 +104,15 @@ class FollowControllerTest {
     void testUnfollow() throws Exception {
         // Given
         followRepository.save(Follow.builder()
-                .user(user1)
-                .followedUser(user2)
+                .source(user1)
+                .target(user2)
                 .build());
 
         final List<Follow> follows = followRepository.findAll();
         assertAll("beforeUnfollow",
                 () -> assertThat(follows.size()).isEqualTo(1),
-                () -> assertThat(follows.get(0).getUser()).isEqualTo(user1),
-                () -> assertThat(follows.get(0).getFollowedUser()).isEqualTo(user2)
+                () -> assertThat(follows.get(0).getSource()).isEqualTo(user1),
+                () -> assertThat(follows.get(0).getTarget()).isEqualTo(user2)
         );
 
         // When
@@ -132,21 +132,21 @@ class FollowControllerTest {
     void testFindFollowerList() throws Exception {
         // Given
         followRepository.save(Follow.builder()
-                .user(user1)
-                .followedUser(user2)
+                .source(user1)
+                .target(user2)
                 .build());
         followRepository.save(Follow.builder()
-                .user(user1)
-                .followedUser(user3)
+                .source(user1)
+                .target(user3)
                 .build());
 
         final List<Follow> allFollow = followRepository.findAll();
         assertAll("user1이 user2, user3을 팔로우",
                 () -> assertThat(allFollow.size()).isEqualTo(2),
-                () -> assertThat(allFollow.get(0).getUser()).isEqualTo(user1),
-                () -> assertThat(allFollow.get(0).getFollowedUser()).isEqualTo(user2),
-                () -> assertThat(allFollow.get(1).getUser()).isEqualTo(user1),
-                () -> assertThat(allFollow.get(1).getFollowedUser()).isEqualTo(user3)
+                () -> assertThat(allFollow.get(0).getSource()).isEqualTo(user1),
+                () -> assertThat(allFollow.get(0).getTarget()).isEqualTo(user2),
+                () -> assertThat(allFollow.get(1).getSource()).isEqualTo(user1),
+                () -> assertThat(allFollow.get(1).getTarget()).isEqualTo(user3)
         );
 
         // When, Then
@@ -163,21 +163,21 @@ class FollowControllerTest {
     void testFollowingList() throws Exception {
         // Given
         followRepository.save(Follow.builder()
-                .user(user1)
-                .followedUser(user2)
+                .source(user1)
+                .target(user2)
                 .build());
         followRepository.save(Follow.builder()
-                .user(user1)
-                .followedUser(user3)
+                .source(user1)
+                .target(user3)
                 .build());
 
         final List<Follow> allFollow = followRepository.findAll();
         assertAll("user1이 user2, user3을 팔로우",
                 () -> assertThat(allFollow.size()).isEqualTo(2),
-                () -> assertThat(allFollow.get(0).getUser()).isEqualTo(user1),
-                () -> assertThat(allFollow.get(0).getFollowedUser()).isEqualTo(user2),
-                () -> assertThat(allFollow.get(1).getUser()).isEqualTo(user1),
-                () -> assertThat(allFollow.get(1).getFollowedUser()).isEqualTo(user3)
+                () -> assertThat(allFollow.get(0).getSource()).isEqualTo(user1),
+                () -> assertThat(allFollow.get(0).getTarget()).isEqualTo(user2),
+                () -> assertThat(allFollow.get(1).getSource()).isEqualTo(user1),
+                () -> assertThat(allFollow.get(1).getTarget()).isEqualTo(user3)
         );
 
         // When, Then
@@ -187,5 +187,4 @@ class FollowControllerTest {
                 .andExpect(status().isOk())
                 .andDo(print());
     }
-
 }

--- a/src/test/java/org/ahpuh/surf/unit/user/service/UserServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/user/service/UserServiceTest.java
@@ -186,9 +186,9 @@ public class UserServiceTest {
 
             given(userRepository.findById(anyLong()))
                     .willReturn(Optional.of(mockUser));
-            given(followRepository.countByUser(mockUser))
+            given(followRepository.countBySource(mockUser))
                     .willReturn(0L);
-            given(followRepository.countByFollowedUser(mockUser))
+            given(followRepository.countByTarget(mockUser))
                     .willReturn(0L);
             given(userConverter.toUserFindInfoResponseDto(any(), eq(0L), eq(0L)))
                     .willReturn(mockUserDto);
@@ -201,9 +201,9 @@ public class UserServiceTest {
             verify(userRepository, times(1))
                     .findById(1L);
             verify(followRepository, times(1))
-                    .countByUser(mockUser);
+                    .countBySource(mockUser);
             verify(followRepository, times(1))
-                    .countByFollowedUser(mockUser);
+                    .countByTarget(mockUser);
             verify(userConverter, times(1))
                     .toUserFindInfoResponseDto(mockUser, 0L, 0L);
         }


### PR DESCRIPTION
## 📄 Description

- close : #107 

> Follow 엔티티의 필드명을 source, target으로 수정합니다.

## 📌 구현 내용

- [x] 필드명 source, target으로 수정
- [x] 관련된 부분 수정

## ✅ PR 포인트

- 헷갈릴만한 상황이 자주 나와서 명확하게 source와 target으로 명시하겠습니다.
