### PR TITLE
엔티티 단위 테스트 코드 추가

### DIFF
--- a/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
@@ -1,13 +1,18 @@
 package org.ahpuh.surf.unit.category.domain;
 
 import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
+import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
+import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
 import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class CategoryTest {
@@ -28,5 +33,19 @@ public class CategoryTest {
                 () -> assertThat(category.getIsPublic()).isFalse(),
                 () -> assertThat(category.getColorCode()).isEqualTo("FFFFFF")
         );
+    }
+
+    @DisplayName("addPost 메소드는 이미 등록된 게시글이 다시 등록되면 예외가 발생한다.")
+    @Test
+    void duplicatedPostException() {
+        // Given
+        final User user = createMockUser();
+        final Category category = createMockCategory(user);
+        final Post post = createMockPost(user, category);
+
+        // When Then
+        assertThatThrownBy(() -> category.addPost(post))
+                .isInstanceOf(DuplicatedPostException.class)
+                .hasMessage("이미 등록된 게시글입니다.");
     }
 }

--- a/src/test/java/org/ahpuh/surf/unit/follow/domain/FollowTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/follow/domain/FollowTest.java
@@ -1,0 +1,33 @@
+package org.ahpuh.surf.unit.follow.domain;
+
+import org.ahpuh.surf.follow.domain.Follow;
+import org.ahpuh.surf.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class FollowTest {
+
+    @DisplayName("팔로우 엔티티를 builder로 생성하면 해당 유저의 팔로우 리스트에 add 된다.")
+    @Test
+    void followBuilderAddTest() {
+        // Given
+        final User user1 = createMockUser("test1@naver.com");
+        final User user2 = createMockUser("test2@naver.com");
+
+        // When
+        Follow.builder()
+                .source(user1)
+                .target(user2)
+                .build();
+
+        // Then
+        assertAll("유저의 팔로우 리스트에 자동 add 되는지 테스트",
+                () -> assertThat(user1.getFollowing().size()).isEqualTo(1),
+                () -> assertThat(user2.getFollowers().size()).isEqualTo(1)
+        );
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/like/domain/LikeTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/like/domain/LikeTest.java
@@ -1,0 +1,38 @@
+package org.ahpuh.surf.unit.like.domain;
+
+import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.like.domain.Like;
+import org.ahpuh.surf.post.domain.Post;
+import org.ahpuh.surf.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
+import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class LikeTest {
+
+    @DisplayName("Like 엔티티를 builder로 생성하면 해당 유저와 게시글의 Like 리스트에 add 된다.")
+    @Test
+    void likeBuilderAddTest() {
+        // Given
+        final User user = createMockUser();
+        final Category category = createMockCategory(user);
+        final Post post = createMockPost(user, category);
+
+        // When
+        Like.builder()
+                .user(user)
+                .post(post)
+                .build();
+
+        // Then
+        assertAll("유저와 게시글의 Like 리스트에 자동 add 되는지 테스트",
+                () -> assertThat(user.getLikes().size()).isEqualTo(1),
+                () -> assertThat(post.getLikes().size()).isEqualTo(1)
+        );
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/post/domain/PostTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/domain/PostTest.java
@@ -1,0 +1,142 @@
+package org.ahpuh.surf.unit.post.domain;
+
+import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.common.exception.like.DuplicatedLikeException;
+import org.ahpuh.surf.common.exception.post.FavoriteInvalidUserException;
+import org.ahpuh.surf.like.domain.Like;
+import org.ahpuh.surf.post.domain.Post;
+import org.ahpuh.surf.s3.FileStatus;
+import org.ahpuh.surf.s3.FileType;
+import org.ahpuh.surf.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
+import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class PostTest {
+
+    @DisplayName("게시글 정보를 수정할 수 있다.")
+    @Test
+    void updatePostTest() {
+        // Given
+        final User user = createMockUser();
+        final Category category = createMockCategory(user);
+        final Post post = createMockPost(user, category);
+
+        // When
+        post.updatePost(category, LocalDate.of(2022, 1, 1), "update", 50);
+
+        // Then
+        assertAll("게시글 정보 수정 테스트",
+                () -> assertThat(post.getSelectedDate()).isEqualTo(LocalDate.of(2022, 1, 1)),
+                () -> assertThat(post.getContent()).isEqualTo("update"),
+                () -> assertThat(post.getScore()).isEqualTo(50)
+        );
+    }
+
+    @DisplayName("updateFile 메소드는")
+    @Nested
+    class UpdateFileMethod {
+
+        @DisplayName("이미지가 들어오면 imageUrl에 파일주소를 저장하고, fileUrl을 비운다.")
+        @Test
+        void imageFileTest() {
+            // Given
+            final User user = createMockUser();
+            final Category category = createMockCategory(user);
+            final Post post = createMockPost(user, category);
+            final FileStatus fileStatus = new FileStatus("updateImageUrl", FileType.IMG);
+
+            // When
+            post.updateFile(fileStatus);
+
+            // Then
+            assertAll("이미지 업로드시",
+                    () -> assertThat(post.getImageUrl()).isEqualTo("updateImageUrl"),
+                    () -> assertThat(post.getFileUrl()).isNull()
+            );
+        }
+
+        @DisplayName("파일이 들어오면 fileUrl에 파일주소를 저장하고, imageUrl을 비운다.")
+        @Test
+        void fileTest() {
+            // Given
+            final User user = createMockUser();
+            final Category category = createMockCategory(user);
+            final Post post = createMockPost(user, category);
+            final FileStatus fileStatus = new FileStatus("updateUrl", FileType.FILE);
+
+            // When
+            post.updateFile(fileStatus);
+
+            // Then
+            assertAll("파일 업로드시",
+                    () -> assertThat(post.getFileUrl()).isEqualTo("updateUrl"),
+                    () -> assertThat(post.getImageUrl()).isNull()
+            );
+        }
+    }
+
+    @DisplayName("updateFavorite 메소드는")
+    @Nested
+    class UpdateFavoriteMethod {
+
+        @DisplayName("해당 게시글을 작성한 유저가 즐겨찾기에 등록할 수 있다.")
+        @Test
+        void updateFavorite() {
+            // Given
+            final User user = createSavedUser();
+            final Category category = createMockCategory(user);
+            final Post post = createMockPost(user, category);
+            assertThat(post.getFavorite()).isFalse();
+
+            // When
+            post.updateFavorite(user.getUserId());
+
+            // Then
+            assertThat(post.getFavorite()).isTrue();
+        }
+
+        @DisplayName("해당 게시글을 작성한 유저가 아닐 경우 예외가 발생한다.")
+        @Test
+        void favoriteUpdateFailException() {
+            // Given
+            final User user = createSavedUser();
+            final Category category = createMockCategory(user);
+            final Post post = createMockPost(user, category);
+            assertThat(post.getFavorite()).isFalse();
+
+            // When Then
+            assertThatThrownBy(() -> post.updateFavorite(100L))
+                    .isInstanceOf(FavoriteInvalidUserException.class)
+                    .hasMessage("즐겨찾기를 등록 또는 취소할 수 없습니다.(내 게시글만 등록 가능)");
+        }
+    }
+
+    @DisplayName("addLike 메소드는 이미 좋아요를 누른 게시글을 다시 좋아요하면 예외가 발생한다.")
+    @Test
+    void duplicatedLikeException() {
+        // Given
+        final User user = createMockUser();
+        final Category category = createMockCategory(user);
+        final Post post = createMockPost(user, category);
+        final Like like = Like.builder()
+                .user(user)
+                .post(post)
+                .build();
+
+        // When Then
+        assertThatThrownBy(() -> post.addLike(like))
+                .isInstanceOf(DuplicatedLikeException.class)
+                .hasMessage("이미 좋아요를 누른 게시글입니다.");
+    }
+}

--- a/src/test/java/org/ahpuh/surf/unit/user/domain/UserTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/user/domain/UserTest.java
@@ -1,6 +1,14 @@
 package org.ahpuh.surf.unit.user.domain;
 
+import org.ahpuh.surf.category.domain.Category;
+import org.ahpuh.surf.common.exception.category.DuplicatedCategoryException;
+import org.ahpuh.surf.common.exception.follow.DuplicatedFollowingException;
+import org.ahpuh.surf.common.exception.like.DuplicatedLikeException;
+import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
 import org.ahpuh.surf.common.exception.user.InvalidPasswordException;
+import org.ahpuh.surf.follow.domain.Follow;
+import org.ahpuh.surf.like.domain.Like;
+import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.user.domain.Permission;
 import org.ahpuh.surf.user.domain.User;
 import org.ahpuh.surf.user.dto.request.UserUpdateRequestDto;
@@ -14,6 +22,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
+import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
 import static org.ahpuh.surf.common.factory.MockUserFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -161,6 +171,90 @@ public class UserTest {
                     () -> assertThat(passwordEncoder.matches("testpw", savedUser.getPassword())).isTrue(),
                     () -> assertThat(savedUser.getProfilePhotoUrl()).isEqualTo("profilePhoto")
             );
+        }
+    }
+
+    @DisplayName("연관관계 매핑 예외")
+    @Nested
+    class EntityMappingExceptions {
+
+        @DisplayName("addCategory 메소드는 이미 등록된 카테고리가 다시 등록되면 예외가 발생한다.")
+        @Test
+        void duplicatedCategoryException() {
+            // Given
+            final User user = createMockUser();
+            final Category category = createMockCategory(user);
+
+            // When Then
+            assertThatThrownBy(() -> user.addCategory(category))
+                    .isInstanceOf(DuplicatedCategoryException.class)
+                    .hasMessage("이미 등록된 카테고리입니다.");
+        }
+
+        @DisplayName("addPost 메소드는 이미 등록된 게시글이 다시 등록되면 예외가 발생한다.")
+        @Test
+        void duplicatedPostException() {
+            // Given
+            final User user = createMockUser();
+            final Category category = createMockCategory(user);
+            final Post post = createMockPost(user, category);
+
+            // When Then
+            assertThatThrownBy(() -> user.addPost(post))
+                    .isInstanceOf(DuplicatedPostException.class)
+                    .hasMessage("이미 등록된 게시글입니다.");
+        }
+
+        @DisplayName("addFollowing 메소드는 이미 팔로우 한 유저가 다시 팔로우하면 예외가 발생한다.")
+        @Test
+        void duplicatedFollowingException_Following() {
+            // Given
+            final User user1 = createMockUser("test1@naver.com");
+            final User user2 = createMockUser("test2@naver.com");
+            final Follow follow = Follow.builder()
+                    .source(user1)
+                    .target(user2)
+                    .build();
+
+            // When Then
+            assertThatThrownBy(() -> user1.addFollowing(follow))
+                    .isInstanceOf(DuplicatedFollowingException.class)
+                    .hasMessage("이미 팔로우 한 사용자입니다.");
+        }
+
+        @DisplayName("addFollowers 메소드는 이미 팔로우 한 유저를 다시 팔로우하면 예외가 발생한다.")
+        @Test
+        void duplicatedFollowingException_Followers() {
+            // Given
+            final User user1 = createMockUser("test1@naver.com");
+            final User user2 = createMockUser("test2@naver.com");
+            final Follow follow = Follow.builder()
+                    .source(user1)
+                    .target(user2)
+                    .build();
+
+            // When Then
+            assertThatThrownBy(() -> user2.addFollowers(follow))
+                    .isInstanceOf(DuplicatedFollowingException.class)
+                    .hasMessage("이미 팔로우 한 사용자입니다.");
+        }
+
+        @DisplayName("addLike 메소드는 이미 좋아요를 누른 게시글을 다시 좋아요하면 예외가 발생한다.")
+        @Test
+        void duplicatedLikeException() {
+            // Given
+            final User user = createMockUser();
+            final Category category = createMockCategory(user);
+            final Post post = createMockPost(user, category);
+            final Like like = Like.builder()
+                    .user(user)
+                    .post(post)
+                    .build();
+
+            // When Then
+            assertThatThrownBy(() -> user.addLike(like))
+                    .isInstanceOf(DuplicatedLikeException.class)
+                    .hasMessage("이미 좋아요를 누른 게시글입니다.");
         }
     }
 }


### PR DESCRIPTION
## 📄 Description

- close : #129 

> 엔티티에 대한 단위 테스트 코드를 추가합니다.

## 📌 구현 내용

- [x] User Entity 단위 테스트
- [x] Category Entity 단위 테스트
- [x] Post Entity 단위 테스트
- [x] Follow Entity 단위 테스트
- [x] Like Entity 단위 테스트
