### PR TITLE
Checked Exception 추가, 리팩토링

### DIFF
--- a/src/main/java/org/ahpuh/surf/common/exception/ExceptionType.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/ExceptionType.java
@@ -6,9 +6,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ExceptionType {
     // JWT
+    USER_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보가 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 없습니다."),
     UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED, "인증되지 않은 토큰입니다."),
-    USER_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보가 없습니다."),
 
     // USER
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
@@ -17,7 +17,7 @@ public enum ExceptionType {
 
     // FOLLOW
     DUPLICATED_FOLLOWING(HttpStatus.BAD_REQUEST, "이미 팔로우 한 사용자입니다."),
-    FOLLOW_NOT_FOUND(HttpStatus.BAD_REQUEST, "팔로우 한 기록이 없습니다."),
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "팔로우 한 기록이 없습니다."),
 
     // CATEGORY
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
@@ -28,14 +28,14 @@ public enum ExceptionType {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
     DUPLICATED_POST(HttpStatus.BAD_REQUEST, "이미 등록된 게시글입니다."),
     NOT_MATCHING_POST_BY_USER(HttpStatus.BAD_REQUEST, "다른 사용자의 게시글을 삭제할 수 없습니다."),
+    INVALID_PERIOD(HttpStatus.BAD_REQUEST, "기간이 잘못 입력되었습니다."),
     FAVORITE_INVALID_USER(HttpStatus.BAD_REQUEST, "즐겨찾기를 등록 또는 취소할 수 없습니다.(내 게시글만 등록 가능)"),
-    FAVORITE_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "이미 실행된 요청입니다."),
     MAKE_FAVORITE_FAIL(HttpStatus.BAD_REQUEST, "이미 즐겨찾기에 추가된 게시글입니다."),
     CANCEL_FAVORITE_FAIL(HttpStatus.BAD_REQUEST, "이미 즐겨찾기 취소된 게시글입니다."),
 
     // LIKE
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 한 기록이 없습니다."),
     DUPLICATED_LIKE(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 게시글입니다."),
-    LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "좋아요 한 기록이 없습니다."),
     INVALID_LIKE_REQUEST(HttpStatus.BAD_REQUEST, "해당 게시글에 대한 좋아요 기록이 아닙니다."),
 
     // S3

--- a/src/main/java/org/ahpuh/surf/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/GlobalExceptionHandler.java
@@ -6,9 +6,13 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.net.BindException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -42,6 +46,39 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(errorMessage));
     }
 
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> bindException(
+            final BindException e
+    ) {
+        final String errorMessage = e.getMessage();
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), errorMessage);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(errorMessage));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentTypeMismatchException(
+            final MethodArgumentTypeMismatchException e
+    ) {
+        final String errorMessage = e.getMessage();
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), errorMessage);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(errorMessage));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> httpRequestMethodNotSupportedException(
+            final HttpRequestMethodNotSupportedException e
+    ) {
+        final String errorMessage = e.getMessage();
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), errorMessage);
+        return ResponseEntity
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(new ErrorResponse(errorMessage));
+    }
+
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<ErrorResponse> applicationException(
             final ApplicationException e
@@ -54,7 +91,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(DataAccessException.class)
-    public ResponseEntity<ErrorResponse> dataAccessException(final DataAccessException e) {
+    public ResponseEntity<ErrorResponse> dataAccessException(
+            final DataAccessException e
+    ) {
         final String errorMessage = e.getMessage();
         log.error(LOG_FORMAT, e.getClass().getSimpleName(), errorMessage);
         return ResponseEntity
@@ -63,7 +102,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<ErrorResponse> runtimeException(final RuntimeException e) {
+    public ResponseEntity<ErrorResponse> runtimeException(
+            final RuntimeException e
+    ) {
         log.error(LOG_FORMAT, e.getClass().getSimpleName(), e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/org/ahpuh/surf/common/exception/post/InvalidPeriodException.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/post/InvalidPeriodException.java
@@ -1,0 +1,11 @@
+package org.ahpuh.surf.common.exception.post;
+
+import org.ahpuh.surf.common.exception.ApplicationException;
+import org.ahpuh.surf.common.exception.ExceptionType;
+
+public class InvalidPeriodException extends ApplicationException {
+
+    public InvalidPeriodException() {
+        super(ExceptionType.INVALID_PERIOD.getHttpStatus(), ExceptionType.INVALID_PERIOD.getDetail());
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #133 

> - Post 도메인의 Checked Exception을 추가합니다.
> - GlobalExceptionHandler에서 `BindException`, `MethodArgumentTypeMismatchException`, `HttpRequestMethodNotSupportedException`을 핸들링하도록 추가합니다.
> - ExceptionType Enum 클래스를 리팩토링합니다.

## 📌 구현 내용

- [x] Checked Exception 추가
- [x] GlobalExceptionHandler 예외 처리 추가
- [x] ExceptionType Enum 클래스 리팩토링
