### PR TITLE
Post 도메인 메소드 수정

### DIFF
--- a/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepository.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryQuerydsl {
 
@@ -14,6 +15,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     List<Post> findAllByCategoryOrderBySelectedDateDesc(Category category, Pageable page);
 
-    Post findTop1ByCategoryOrderBySelectedDateDesc(Category category);
+    Optional<Post> findTop1ByCategoryOrderBySelectedDateDesc(Category category);
 
 }

--- a/src/main/java/org/ahpuh/surf/post/service/PostService.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostService.java
@@ -117,10 +117,11 @@ public class PostService {
 
     public PostsRecentScoreResponseDto getRecentScore(final Long categoryId) {
         final Category category = getCategory(categoryId);
-        final Integer recentScore = postRepository.findTop1ByCategoryOrderBySelectedDateDesc(category)
-                .getScore();
-
-        return new PostsRecentScoreResponseDto(recentScore);
+        Optional<Post> findedPost = postRepository.findTop1ByCategoryOrderBySelectedDateDesc(category);
+        
+        return findedPost.isEmpty()
+                ? new PostsRecentScoreResponseDto(null)
+                : new PostsRecentScoreResponseDto(findedPost.get().getScore());
     }
 
     public List<PostCountResponseDto> getPostCountsOfYear(final int year, final Long userId) {

--- a/src/main/java/org/ahpuh/surf/post/service/PostService.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostService.java
@@ -106,7 +106,7 @@ public class PostService {
     public List<PostsOfMonthResponseDto> getPostsOfMonth(final Long userId, final Integer year, final Integer month) {
         if (Objects.isNull(year) | Objects.isNull(month)) {
             throw new InvalidPeriodException();
-        } else if (year < 1900 | month > 12 | month < 1) {
+        } else if (month > 12 | month < 1) {
             throw new InvalidPeriodException();
         }
         final LocalDate startDate = LocalDate.of(year, month, 1);


### PR DESCRIPTION
## 📄 Description

- close : #144 

> `findTop1ByCategoryOrderBySelectedDateDesc()` 메소드가 Post를 반환하는걸 Optional<Post>로 수정하고,
> empty인 경우 로직을 추가합니다.

## 📌 구현 내용

- [x] 메소드 반환값 Optional로 설정
- [x] empty인 경우 로직 추가
