### PR TITLE
연관관계 편의 메소드 수정

### DIFF
--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.Where;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -64,7 +65,7 @@ public class Category extends BaseEntity {
     }
 
     public void addPost(final Post post) {
-        if (posts.isEmpty()) {
+        if (Objects.isNull(posts)) {
             posts = new ArrayList<>();
         }
         posts.add(post);

--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ahpuh.surf.common.domain.BaseEntity;
-import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
 import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.user.domain.User;
 import org.hibernate.annotations.Formula;
@@ -65,8 +64,8 @@ public class Category extends BaseEntity {
     }
 
     public void addPost(final Post post) {
-        if (posts.contains(post)) {
-            throw new DuplicatedPostException();
+        if (posts.isEmpty()) {
+            posts = new ArrayList<>();
         }
         posts.add(post);
     }

--- a/src/main/java/org/ahpuh/surf/like/controller/LikeController.java
+++ b/src/main/java/org/ahpuh/surf/like/controller/LikeController.java
@@ -29,7 +29,7 @@ public class LikeController {
             @PathVariable final Long postId,
             @PathVariable final Long likeId
     ) {
-        likeService.unlike(postId, likeId);
+        likeService.unlike(likeId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/ahpuh/surf/like/domain/LikeRepository.java
+++ b/src/main/java/org/ahpuh/surf/like/domain/LikeRepository.java
@@ -1,6 +1,11 @@
 package org.ahpuh.surf.like.domain;
 
+import org.ahpuh.surf.post.domain.Post;
+import org.ahpuh.surf.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    boolean existsByUserAndPost(User user, Post post);
+
 }

--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -18,6 +18,7 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -99,7 +100,7 @@ public class Post extends BaseEntity {
     }
 
     public void addLike(final Like like) {
-        if (likes.isEmpty()) {
+        if (Objects.isNull(likes)) {
             likes = new ArrayList<>();
         }
         likes.add(like);

--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.ahpuh.surf.category.domain.Category;
 import org.ahpuh.surf.common.domain.BaseEntity;
-import org.ahpuh.surf.common.exception.like.DuplicatedLikeException;
 import org.ahpuh.surf.common.exception.post.FavoriteInvalidUserException;
 import org.ahpuh.surf.like.domain.Like;
 import org.ahpuh.surf.s3.domain.FileStatus;
@@ -100,8 +99,8 @@ public class Post extends BaseEntity {
     }
 
     public void addLike(final Like like) {
-        if (likes.contains(like)) {
-            throw new DuplicatedLikeException();
+        if (likes.isEmpty()) {
+            likes = new ArrayList<>();
         }
         likes.add(like);
     }

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -120,35 +120,35 @@ public class User extends BaseEntity {
     }
 
     public void addCategory(final Category category) {
-        if (categories.isEmpty()) {
+        if (Objects.isNull(categories)) {
             categories = new ArrayList<>();
         }
         categories.add(category);
     }
 
     public void addPost(final Post post) {
-        if (posts.isEmpty()) {
+        if (Objects.isNull(posts)) {
             posts = new ArrayList<>();
         }
         posts.add(post);
     }
 
     public void addFollowing(final Follow followingUser) {
-        if (following.isEmpty()) {
+        if (Objects.isNull(following)) {
             following = new ArrayList<>();
         }
         following.add(followingUser);
     }
 
     public void addFollowers(final Follow follower) {
-        if (followers.isEmpty()) {
+        if (Objects.isNull(followers)) {
             followers = new ArrayList<>();
         }
         followers.add(follower);
     }
 
     public void addLike(final Like like) {
-        if (likes.isEmpty()) {
+        if (Objects.isNull(likes)) {
             likes = new ArrayList<>();
         }
         likes.add(like);

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -3,10 +3,6 @@ package org.ahpuh.surf.user.domain;
 import lombok.*;
 import org.ahpuh.surf.category.domain.Category;
 import org.ahpuh.surf.common.domain.BaseEntity;
-import org.ahpuh.surf.common.exception.category.DuplicatedCategoryException;
-import org.ahpuh.surf.common.exception.follow.DuplicatedFollowingException;
-import org.ahpuh.surf.common.exception.like.DuplicatedLikeException;
-import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
 import org.ahpuh.surf.common.exception.user.InvalidPasswordException;
 import org.ahpuh.surf.follow.domain.Follow;
 import org.ahpuh.surf.like.domain.Like;
@@ -124,36 +120,36 @@ public class User extends BaseEntity {
     }
 
     public void addCategory(final Category category) {
-        if (categories.contains(category)) {
-            throw new DuplicatedCategoryException();
+        if (categories.isEmpty()) {
+            categories = new ArrayList<>();
         }
         categories.add(category);
     }
 
     public void addPost(final Post post) {
-        if (posts.contains(post)) {
-            throw new DuplicatedPostException();
+        if (posts.isEmpty()) {
+            posts = new ArrayList<>();
         }
         posts.add(post);
     }
 
     public void addFollowing(final Follow followingUser) {
-        if (following.contains(followingUser)) {
-            throw new DuplicatedFollowingException();
+        if (following.isEmpty()) {
+            following = new ArrayList<>();
         }
         following.add(followingUser);
     }
 
     public void addFollowers(final Follow follower) {
-        if (followers.contains(follower)) {
-            throw new DuplicatedFollowingException();
+        if (followers.isEmpty()) {
+            followers = new ArrayList<>();
         }
         followers.add(follower);
     }
 
     public void addLike(final Like like) {
-        if (likes.contains(like)) {
-            throw new DuplicatedLikeException();
+        if (likes.isEmpty()) {
+            likes = new ArrayList<>();
         }
         likes.add(like);
     }

--- a/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
@@ -1,18 +1,13 @@
 package org.ahpuh.surf.unit.category.domain;
 
 import org.ahpuh.surf.category.domain.Category;
-import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
-import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
-import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
-import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
 import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class CategoryTest {
@@ -33,19 +28,5 @@ public class CategoryTest {
                 () -> assertThat(category.getIsPublic()).isFalse(),
                 () -> assertThat(category.getColorCode()).isEqualTo("FFFFFF")
         );
-    }
-
-    @DisplayName("addPost 메소드는 이미 등록된 게시글이 다시 등록되면 예외가 발생한다.")
-    @Test
-    void duplicatedPostException() {
-        // Given
-        final User user = createMockUser();
-        final Category category = createMockCategory(user);
-        final Post post = createMockPost(user, category);
-
-        // When Then
-        assertThatThrownBy(() -> category.addPost(post))
-                .isInstanceOf(DuplicatedPostException.class)
-                .hasMessage("이미 등록된 게시글입니다.");
     }
 }

--- a/src/test/java/org/ahpuh/surf/unit/post/domain/PostTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/domain/PostTest.java
@@ -1,9 +1,7 @@
 package org.ahpuh.surf.unit.post.domain;
 
 import org.ahpuh.surf.category.domain.Category;
-import org.ahpuh.surf.common.exception.like.DuplicatedLikeException;
 import org.ahpuh.surf.common.exception.post.FavoriteInvalidUserException;
-import org.ahpuh.surf.like.domain.Like;
 import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.s3.domain.FileStatus;
 import org.ahpuh.surf.s3.domain.FileType;
@@ -15,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 
 import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
-import static org.ahpuh.surf.common.factory.MockLikeFactory.createMockLike;
 import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
 import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
 import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
@@ -121,20 +118,5 @@ public class PostTest {
                     .isInstanceOf(FavoriteInvalidUserException.class)
                     .hasMessage("즐겨찾기를 등록 또는 취소할 수 없습니다.(내 게시글만 등록 가능)");
         }
-    }
-
-    @DisplayName("addLike 메소드는 이미 좋아요를 누른 게시글을 다시 좋아요하면 예외가 발생한다.")
-    @Test
-    void duplicatedLikeException() {
-        // Given
-        final User user = createMockUser();
-        final Category category = createMockCategory(user);
-        final Post post = createMockPost(user, category);
-        final Like like = createMockLike(user, post);
-
-        // When Then
-        assertThatThrownBy(() -> post.addLike(like))
-                .isInstanceOf(DuplicatedLikeException.class)
-                .hasMessage("이미 좋아요를 누른 게시글입니다.");
     }
 }

--- a/src/test/java/org/ahpuh/surf/unit/user/domain/UserTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/user/domain/UserTest.java
@@ -1,14 +1,6 @@
 package org.ahpuh.surf.unit.user.domain;
 
-import org.ahpuh.surf.category.domain.Category;
-import org.ahpuh.surf.common.exception.category.DuplicatedCategoryException;
-import org.ahpuh.surf.common.exception.follow.DuplicatedFollowingException;
-import org.ahpuh.surf.common.exception.like.DuplicatedLikeException;
-import org.ahpuh.surf.common.exception.post.DuplicatedPostException;
 import org.ahpuh.surf.common.exception.user.InvalidPasswordException;
-import org.ahpuh.surf.follow.domain.Follow;
-import org.ahpuh.surf.like.domain.Like;
-import org.ahpuh.surf.post.domain.Post;
 import org.ahpuh.surf.user.domain.Permission;
 import org.ahpuh.surf.user.domain.User;
 import org.ahpuh.surf.user.dto.request.UserUpdateRequestDto;
@@ -24,10 +16,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
-import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
-import static org.ahpuh.surf.common.factory.MockFollowFactory.createMockFollow;
-import static org.ahpuh.surf.common.factory.MockLikeFactory.createMockLike;
-import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
 import static org.ahpuh.surf.common.factory.MockUserFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -175,81 +163,6 @@ public class UserTest {
                     () -> assertThat(passwordEncoder.matches("testpw", savedUser.getPassword())).isTrue(),
                     () -> assertThat(savedUser.getProfilePhotoUrl()).isEqualTo("profilePhoto")
             );
-        }
-    }
-
-    @DisplayName("연관관계 매핑 예외")
-    @Nested
-    class EntityMappingExceptions {
-
-        @DisplayName("addCategory 메소드는 이미 등록된 카테고리가 다시 등록되면 예외가 발생한다.")
-        @Test
-        void duplicatedCategoryException() {
-            // Given
-            final User user = createMockUser();
-            final Category category = createMockCategory(user);
-
-            // When Then
-            assertThatThrownBy(() -> user.addCategory(category))
-                    .isInstanceOf(DuplicatedCategoryException.class)
-                    .hasMessage("이미 등록된 카테고리입니다.");
-        }
-
-        @DisplayName("addPost 메소드는 이미 등록된 게시글이 다시 등록되면 예외가 발생한다.")
-        @Test
-        void duplicatedPostException() {
-            // Given
-            final User user = createMockUser();
-            final Category category = createMockCategory(user);
-            final Post post = createMockPost(user, category);
-
-            // When Then
-            assertThatThrownBy(() -> user.addPost(post))
-                    .isInstanceOf(DuplicatedPostException.class)
-                    .hasMessage("이미 등록된 게시글입니다.");
-        }
-
-        @DisplayName("addFollowing 메소드는 이미 팔로우 한 유저가 다시 팔로우하면 예외가 발생한다.")
-        @Test
-        void duplicatedFollowingException_Following() {
-            // Given
-            final User user1 = createMockUser("test1@naver.com");
-            final User user2 = createMockUser("test2@naver.com");
-            final Follow follow = createMockFollow(user1, user2);
-
-            // When Then
-            assertThatThrownBy(() -> user1.addFollowing(follow))
-                    .isInstanceOf(DuplicatedFollowingException.class)
-                    .hasMessage("이미 팔로우 한 사용자입니다.");
-        }
-
-        @DisplayName("addFollowers 메소드는 이미 팔로우 한 유저를 다시 팔로우하면 예외가 발생한다.")
-        @Test
-        void duplicatedFollowingException_Followers() {
-            // Given
-            final User user1 = createMockUser("test1@naver.com");
-            final User user2 = createMockUser("test2@naver.com");
-            final Follow follow = createMockFollow(user1, user2);
-
-            // When Then
-            assertThatThrownBy(() -> user2.addFollowers(follow))
-                    .isInstanceOf(DuplicatedFollowingException.class)
-                    .hasMessage("이미 팔로우 한 사용자입니다.");
-        }
-
-        @DisplayName("addLike 메소드는 이미 좋아요를 누른 게시글을 다시 좋아요하면 예외가 발생한다.")
-        @Test
-        void duplicatedLikeException() {
-            // Given
-            final User user = createMockUser();
-            final Category category = createMockCategory(user);
-            final Post post = createMockPost(user, category);
-            final Like like = createMockLike(user, post);
-
-            // When Then
-            assertThatThrownBy(() -> user.addLike(like))
-                    .isInstanceOf(DuplicatedLikeException.class)
-                    .hasMessage("이미 좋아요를 누른 게시글입니다.");
         }
     }
 }


### PR DESCRIPTION
## 📄 Description

- close : #158 

> 이전에는 연관된 entity를 생성할 때 연관관계 주인에 있는 List에 contain 되어있는지 확인하고, 있다면 예외를 발생시켰었다.
> ```
> public void addFollowing(final Follow followingUser) {
>     if (following.contains(followingUser)) {
>         throw new DuplicatedFollowingException();
>     }
>     following.add(followingUser);
> }
> ```
> 하지만 다시 생각해보니 save하기 전이라 id값이 없어서 contain 되어있는지 확인할 수가 없다.
> 그래서 연관관계 편의 메소드를 전부 수정하고, 해당 예외처리는 service layer에서 하도록 수정한다.

## 📌 구현 내용

- [x] 연관관계 편의 메소드 수정
- [x] 예외처리 추가
- [x] 테스트 코드 수정
