### PR TITLE
불필요한 부분 삭제, 검증 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     // database
@@ -54,9 +55,6 @@ dependencies {
     implementation 'ch.qos.logback:logback-core:1.2.8'
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
     implementation 'com.github.maricn:logback-slack-appender:1.4.0'
-
-    implementation 'com.google.guava:guava:23.0'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
@@ -127,7 +125,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.50
+                minimum = 0.80
             }
 
             excludes = []

--- a/src/main/java/org/ahpuh/surf/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/ahpuh/surf/jwt/JwtAuthenticationFilter.java
@@ -39,7 +39,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
         if (Objects.isNull(SecurityContextHolder.getContext().getAuthentication())) {
             final String token = getToken(request);
-            if (!Objects.isNull(token)) {
+            if (isNotEmpty(token)) {
                 try {
                     final Claims claims = verify(token);
                     log.debug("Jwt parse result: {}", claims);
@@ -48,7 +48,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                     final String email = claims.getEmail();
                     final List<GrantedAuthority> authorities = getAuthorities(claims);
 
-                    if (!Objects.isNull(userId) && !Objects.isNull(email) && authorities.size() > 0) {
+                    if (!Objects.isNull(userId) && isNotEmpty(email) && authorities.size() > 0) {
                         final JwtAuthenticationToken authentication =
                                 new JwtAuthenticationToken(new JwtAuthentication(token, userId, email), null, authorities);
                         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

--- a/src/main/java/org/ahpuh/surf/s3/service/MockS3Service.java
+++ b/src/main/java/org/ahpuh/surf/s3/service/MockS3Service.java
@@ -11,8 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Profile("test")
 @Service
@@ -35,11 +37,11 @@ public class MockS3Service implements S3Service {
         }
 
         String fileUrl = uploadFile(file);
-        if (!Objects.isNull(fileUrl)) {
+        if (isNotEmpty(fileUrl)) {
             return Optional.of(new FileStatus(fileUrl, FileType.FILE));
         }
         fileUrl = uploadImg(file);
-        if (!Objects.isNull(fileUrl)) {
+        if (isNotEmpty(fileUrl)) {
             return Optional.of(new FileStatus(fileUrl, FileType.IMAGE));
         }
 
@@ -67,7 +69,7 @@ public class MockS3Service implements S3Service {
 
     public String getFileName(final MultipartFile file) {
         final String fileName = file.getOriginalFilename();
-        if (Objects.isNull(fileName) | fileName.isEmpty()) {
+        if (isEmpty(fileName)) {
             throw new InvalidFileNameException();
         }
         return fileName;

--- a/src/main/java/org/ahpuh/surf/s3/service/S3ServiceImpl.java
+++ b/src/main/java/org/ahpuh/surf/s3/service/S3ServiceImpl.java
@@ -21,8 +21,10 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Profile("!test")
 @Service
@@ -69,11 +71,11 @@ public class S3ServiceImpl implements S3Service {
         }
 
         String fileUrl = uploadFile(file);
-        if (!Objects.isNull(fileUrl)) {
+        if (isNotEmpty(fileUrl)) {
             return Optional.of(new FileStatus(fileUrl, FileType.FILE));
         }
         fileUrl = uploadImg(file);
-        if (!Objects.isNull(fileUrl)) {
+        if (isNotEmpty(fileUrl)) {
             return Optional.of(new FileStatus(fileUrl, FileType.IMAGE));
         }
 
@@ -107,7 +109,7 @@ public class S3ServiceImpl implements S3Service {
 
     private String getFileName(final MultipartFile file) {
         final String fileName = file.getOriginalFilename();
-        if (Objects.isNull(fileName) | fileName.isEmpty()) {
+        if (isEmpty(fileName)) {
             throw new InvalidFileNameException();
         }
         return fileName;

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -109,7 +111,7 @@ public class User extends BaseEntity {
     }
 
     public void update(final PasswordEncoder passwordEncoder, final UserUpdateRequestDto request, final Optional<String> profilePhotoUrl) {
-        if (!Objects.isNull(request.getPassword())) {
+        if (isNotEmpty(request.getPassword())) {
             this.password = passwordEncoder.encode(request.getPassword());
         }
         this.userName = request.getUserName();

--- a/src/test/java/org/ahpuh/surf/unit/post/domain/PostQueryDslTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/domain/PostQueryDslTest.java
@@ -128,7 +128,7 @@ public class PostQueryDslTest {
 
         @DisplayName("같은 날짜(selectedDate)로 지정되어 작성됐다면 생성 날짜(createdAt)를 기준으로 내림차순 정렬한다.")
         @Test
-        void sameSelectedDate_orderByCreatedAt() {
+        void sameSelectedDate_orderByCreatedAt() throws InterruptedException {
             // Given
             final User user = createMockUser();
             final Long userId = testEntityManager.persist(user).getUserId();
@@ -138,8 +138,10 @@ public class PostQueryDslTest {
 
             testEntityManager.persist(
                     createMockPostWithContent(user, category, "post1"));
+            Thread.sleep(0, 1);
             testEntityManager.persist(
                     createMockPostWithContent(user, category, "post2"));
+            Thread.sleep(0, 1);
             testEntityManager.persist(
                     createMockPostWithContent(user, category, "post3"));
 


### PR DESCRIPTION
## 📄 Description

- close : #167 

> - 안쓰는 dependency를 정리합니다.
> - null check를 하는 부분에 empty값도 검증이 필요한 부분을 StringUtils.isNotEmpty로 수정합니다.
> - 엔티티 생성시각(createdAt)을 기준으로 비교하는 로직에서 같은 시각에 생성되는 경우가 있어서,
> 최소 1ns의 시간 차이를 주기 위해 Thread.sleep(0, 1)을 추가합니다.

## 📌 구현 내용

- [x] dependency 정리
- [x] null 체크 로직 수정
- [x] createdAt 시간 차이를 주기 위한 추가 설정
