### PR TITLE
인수 테스트 config 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'io.rest-assured:rest-assured:4.4.0'
 }
 
 // QueryDsl 설정 시작
@@ -79,15 +80,12 @@ sourceSets {
     main.java.srcDir querydslDir
 }
 
-compileQuerydsl {
-    options.annotationProcessorPath = configurations.querydsl
+configurations {
+    querydsl.extendsFrom compileClasspath
 }
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
-    }
-    querydsl.extendsFrom compileClasspath
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
 //  QueryDsl 설정 끝
 

--- a/src/test/java/org/ahpuh/surf/acceptance/AcceptanceTest.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/AcceptanceTest.java
@@ -1,0 +1,44 @@
+package org.ahpuh.surf.acceptance;
+
+import io.restassured.RestAssured;
+import org.ahpuh.surf.jwt.Claims;
+import org.ahpuh.surf.jwt.Jwt;
+import org.ahpuh.surf.user.domain.Permission;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class AcceptanceTest {
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @Autowired
+    private Jwt jwt;
+
+    @LocalServerPort
+    private int port;
+
+    protected String TOKEN;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @BeforeEach
+    void setToken() {
+        final String[] roles = new String[]{Permission.ROLE_USER.getRole()};
+        TOKEN = jwt.sign(Claims.from(1L, "test1@naver.com", roles));
+    }
+
+    @AfterEach
+    void cleanUpDatabase() {
+        databaseCleaner.cleanUp();
+    }
+}

--- a/src/test/java/org/ahpuh/surf/acceptance/DatabaseCleaner.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/DatabaseCleaner.java
@@ -1,0 +1,54 @@
+package org.ahpuh.surf.acceptance;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.metamodel.EntityType;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ActiveProfiles("test")
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> entityNames;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        entityNames = entityManager.getMetamodel().getEntities().stream()
+                .filter(entityType -> entityType.getJavaType().getAnnotation(Entity.class) != null)
+                .map(EntityType::getName)
+                .collect(Collectors.toList());
+        tableNames = entityNames.stream()
+                .map(entityName -> switch (entityName) {
+                    case "User" -> "USERS";
+                    case "Category" -> "CATEGORIES";
+                    case "Post" -> "POSTS";
+                    case "Like" -> "LIKES";
+                    default -> entityName;
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void cleanUp() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+        for (int i = 0; i < tableNames.size(); i++) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableNames.get(i)).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableNames.get(i) +
+                    " ALTER COLUMN " + entityNames.get(i) + "_id RESTART WITH 1").executeUpdate();
+        }
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+    }
+}

--- a/src/test/java/org/ahpuh/surf/integration/IntegrationTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/IntegrationTest.java
@@ -1,18 +1,18 @@
 package org.ahpuh.surf.integration;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.transaction.Transactional;
 
 @ActiveProfiles("test")
 @Transactional
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 public abstract class IntegrationTest {
 
-    @Autowired
+    @PersistenceContext
     protected EntityManager entityManager;
 
 }


### PR DESCRIPTION
## 📄 Description

- close : #173 

> Rest-Assured로 인수 테스트를 작성하기 위해 환경을 세팅합니다.

## 📌 구현 내용

- [x] build.gradle 수정
- [x] 통합 테스트 환경 수정
- [x] AcceptanceTest abstract 클래스 생성
- [x] DatabaseCleaner Configuration 추가

## ✅ PR 포인트

- 통합테스트 환경과 별개의 Context를 띄우기 위해  
Service Layer **통합테스트 환경**은 SpringBootTest 옵션을 `default(Mock)`로 설정하고,  
End to End **인수테스트 환경**을 `RandomPort`로 설정했습니다.
- 각 테스트가 다음 테스트에 영향을 주는 문제가 있어서 DatabaseCleaner 클래스를 만들었습니다.  
모든 엔티티명을 받아서 해당 테이블을 truncate 합니다.  
이때, auto_increment 값이 초기화 되지않는 문제가 있어서 `ALTER COLUMN entity_id RESTART WITH 1` 작업을 추가했습니다.  
PK 컬럼명을 id로 통일했으면 더 간단해졌겠네요..!
    ```java
    @Transactional
    public void cleanUp() {
        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();

        for (int i = 0; i < tableNames.size(); i++) {
            entityManager.createNativeQuery("TRUNCATE TABLE " + tableNames.get(i)).executeUpdate();
            entityManager.createNativeQuery("ALTER TABLE " + tableNames.get(i) +
                    " ALTER COLUMN " + entityNames.get(i) + "_id RESTART WITH 1").executeUpdate();
        }

        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
    }
    ```