### PR TITLE
User 도메인 인수테스트 작성

### DIFF
--- a/src/test/java/org/ahpuh/surf/acceptance/AcceptanceTest.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/AcceptanceTest.java
@@ -27,7 +27,7 @@ public abstract class AcceptanceTest {
     protected String TOKEN;
 
     @BeforeEach
-    void setUp() {
+    void setPort() {
         RestAssured.port = port;
     }
 

--- a/src/test/java/org/ahpuh/surf/acceptance/user/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/user/UserControllerTest.java
@@ -1,0 +1,187 @@
+package org.ahpuh.surf.acceptance.user;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.ahpuh.surf.acceptance.AcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.ahpuh.surf.common.factory.MockFileFactory.createImageFile;
+import static org.ahpuh.surf.common.factory.MockFileFactory.invalidFile;
+import static org.ahpuh.surf.common.fixture.TUser.USER_1;
+import static org.ahpuh.surf.common.fixture.TUser.USER_2;
+
+public class UserControllerTest extends AcceptanceTest {
+
+    @DisplayName("회원가입")
+    @Nested
+    class 회원가입 {
+
+        @Test
+        void 회원가입_성공() {
+            // When
+            USER_1.회원가입_요청();
+
+            // Then
+            USER_1.response.statusCode(201);
+        }
+
+        @Test
+        void 중복된_이메일_실패() {
+            // Given
+            USER_1.회원가입_완료();
+            final String duplicatedEmail = "user1@naver.com";
+
+            // When
+            USER_2.회원가입_요청(duplicatedEmail);
+
+            // Then
+            USER_2.response.statusCode(400);
+        }
+    }
+
+    @DisplayName("로그인")
+    @Nested
+    class 로그인 {
+
+        @Test
+        void 로그인_성공() {
+            // Given
+            USER_1.회원가입_완료();
+
+            // When
+            USER_1.로그인_요청();
+
+            // Then
+            USER_1.response.statusCode(200);
+        }
+
+        @Test
+        void 존재하지_않는_유저_실패() {
+            // Given
+            USER_1.회원가입_하지_않음();
+
+            // When
+            USER_1.로그인_요청();
+
+            // Then
+            USER_1.response.statusCode(404);
+        }
+
+        @Test
+        void 틀린_비밀번호_실패() {
+            // Given
+            USER_1.회원가입_완료();
+            final String invalidPassword = "invalidPassword";
+
+            // When
+            USER_1.로그인_요청(invalidPassword);
+
+            // Then
+            USER_1.response.statusCode(400);
+        }
+    }
+
+    @DisplayName("유저정보 조회")
+    @Nested
+    class 유저정보_조회 {
+
+        @Test
+        void 유저정보_조회_성공() {
+            // Given
+            USER_1.회원가입_완료();
+
+            // When
+            USER_1.유저조회_요청(TOKEN, 1L);
+
+            // Then
+            USER_1.response.statusCode(200);
+        }
+
+        @Test
+        void 존재하지_않는_유저_아이디_실패() {
+            // Given
+            USER_1.회원가입_완료();
+            final Long invalidUserId = 2L;
+
+            // When
+            USER_1.유저조회_요청(TOKEN, invalidUserId);
+
+            // Then
+            USER_1.response.statusCode(404);
+        }
+    }
+
+    @DisplayName("유저정보 수정")
+    @Nested
+    class 유저정보_수정 {
+
+        @Test
+        void 유저정보_수정_프로필이미지_첨부O_성공() throws JsonProcessingException {
+            // Given
+            USER_1.회원가입_완료();
+            final File profileImage = createImageFile();
+
+            // When
+            USER_1.유저정보_수정_요청_With_File(TOKEN, profileImage);
+
+            // Then
+            USER_1.response.statusCode(200);
+        }
+
+        @Test
+        void 유저정보_수정_프로필이미지_첨부X_성공() throws JsonProcessingException {
+            // Given
+            USER_1.회원가입_완료();
+
+            // When
+            USER_1.유저정보_수정_요청_No_File(TOKEN);
+
+            // Then
+            USER_1.response.statusCode(200);
+        }
+
+        @Test
+        void 유저정보_수정_With_잘못된_File_실패() throws JsonProcessingException {
+            // Given
+            USER_1.회원가입_완료();
+
+            // When
+            USER_1.유저정보_수정_요청_With_File(TOKEN, invalidFile());
+
+            // Then
+            USER_1.response.statusCode(400);
+        }
+    }
+
+    @DisplayName("유저삭제")
+    @Nested
+    class 유저삭제 {
+
+        @Test
+        void 유저삭제_성공() {
+            // Given
+            USER_1.회원가입_완료();
+
+            // When
+            USER_1.회원탈퇴_요청(TOKEN);
+
+            // Then
+            USER_1.response.statusCode(204);
+        }
+
+        @Test
+        void 존재하지_않는_유저_아이디_실패() {
+            // Given
+            USER_1.회원가입_하지_않음();
+
+            // When
+            USER_1.회원탈퇴_요청(TOKEN);
+
+            // Then
+            USER_1.response.statusCode(404);
+        }
+    }
+}

--- a/src/test/java/org/ahpuh/surf/acceptance/user/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/user/UserControllerTest.java
@@ -1,6 +1,5 @@
 package org.ahpuh.surf.acceptance.user;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.ahpuh.surf.acceptance.AcceptanceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -119,7 +118,7 @@ public class UserControllerTest extends AcceptanceTest {
     class 유저정보_수정 {
 
         @Test
-        void 유저정보_수정_프로필이미지_첨부O_성공() throws JsonProcessingException {
+        void 유저정보_수정_프로필이미지_첨부O_성공() {
             // Given
             USER_1.회원가입_완료();
             final File profileImage = createImageFile();
@@ -132,7 +131,7 @@ public class UserControllerTest extends AcceptanceTest {
         }
 
         @Test
-        void 유저정보_수정_프로필이미지_첨부X_성공() throws JsonProcessingException {
+        void 유저정보_수정_프로필이미지_첨부X_성공() {
             // Given
             USER_1.회원가입_완료();
 
@@ -144,7 +143,7 @@ public class UserControllerTest extends AcceptanceTest {
         }
 
         @Test
-        void 유저정보_수정_With_잘못된_File_실패() throws JsonProcessingException {
+        void 유저정보_수정_With_잘못된_File_실패() {
             // Given
             USER_1.회원가입_완료();
 

--- a/src/test/java/org/ahpuh/surf/common/factory/MockFileFactory.java
+++ b/src/test/java/org/ahpuh/surf/common/factory/MockFileFactory.java
@@ -24,6 +24,18 @@ public class MockFileFactory {
         return textToMultipart(file);
     }
 
+    public static File createImageFile() {
+        return createFile("testImage.png");
+    }
+
+    public static File createTextFile() {
+        return createFile("testText.txt");
+    }
+
+    public static File invalidFile() {
+        return createFile("invalidFile.invalid");
+    }
+
     public static MockMultipartFile createEmptyFile() {
         return new MockMultipartFile(
                 FILE_KEY,

--- a/src/test/java/org/ahpuh/surf/common/factory/MockUserFactory.java
+++ b/src/test/java/org/ahpuh/surf/common/factory/MockUserFactory.java
@@ -84,10 +84,32 @@ public class MockUserFactory {
                 .build();
     }
 
+    public static UserJoinRequestDto createUserJoinRequestDtoWithEmail(final String email) {
+        return UserJoinRequestDto.builder()
+                .email(email)
+                .password("testpw")
+                .userName("mock")
+                .build();
+    }
+
     public static UserLoginRequestDto createUserLoginRequestDto() {
         return UserLoginRequestDto.builder()
                 .email("test1@naver.com")
                 .password("testpw")
+                .build();
+    }
+
+    public static UserLoginRequestDto createUserLoginRequestDto(final String email) {
+        return UserLoginRequestDto.builder()
+                .email(email)
+                .password("testpw")
+                .build();
+    }
+
+    public static UserLoginRequestDto createUserLoginRequestDto(final String email, final String password) {
+        return UserLoginRequestDto.builder()
+                .email(email)
+                .password(password)
                 .build();
     }
 

--- a/src/test/java/org/ahpuh/surf/common/fixture/TUser.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/TUser.java
@@ -1,0 +1,106 @@
+package org.ahpuh.surf.common.fixture;
+
+import io.restassured.http.Method;
+import io.restassured.response.ValidatableResponse;
+import org.apache.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.io.File;
+
+import static io.restassured.RestAssured.given;
+import static org.ahpuh.surf.common.factory.MockUserFactory.*;
+import static org.ahpuh.surf.common.mapper.DtoObjectMapper.mapToString;
+
+public enum TUser {
+    USER_1("user1"),
+    USER_2("user2"),
+    USER_3("user3"),
+    USER_4("user4"),
+    USER_5("user5");
+
+    public String email;
+    public String userName;
+    public ValidatableResponse response;
+
+    TUser(final String userName) {
+        this.userName = userName;
+        this.email = userName + "@naver.com";
+    }
+
+    public void 회원가입_요청() {
+        this.response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createUserJoinRequestDtoWithEmail(email))
+                .request(Method.POST, "/api/v1/users")
+                .then();
+    }
+
+    public void 회원가입_요청(final String email) {
+        this.response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createUserJoinRequestDtoWithEmail(email))
+                .request(Method.POST, "/api/v1/users")
+                .then();
+    }
+
+    public void 회원가입_완료() {
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createUserJoinRequestDtoWithEmail(email))
+                .request(Method.POST, "/api/v1/users");
+    }
+
+    public void 회원가입_하지_않음() {}
+
+    public void 로그인_요청() {
+        this.response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createUserLoginRequestDto(email))
+                .request(Method.POST, "/api/v1/users/login")
+                .then();
+    }
+
+    public void 로그인_요청(final String password) {
+        this.response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createUserLoginRequestDto(email, password))
+                .request(Method.POST, "/api/v1/users/login")
+                .then();
+    }
+
+    public void 유저조회_요청(final String token, final Long userId) {
+        this.response = given()
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .request(Method.GET, "/api/v1/users/{userId}", userId)
+                .then();
+    }
+
+    public void 유저정보_수정_요청_With_File(final String token, final File file) {
+        this.response = given()
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .multiPart("file",
+                        file,
+                        MediaType.MULTIPART_FORM_DATA_VALUE)
+                .multiPart("request",
+                        mapToString(createUserUpdateRequestDto()),
+                        MediaType.APPLICATION_JSON_VALUE)
+                .request(Method.PUT, "/api/v1/users")
+                .then();
+    }
+
+    public void 유저정보_수정_요청_No_File(final String token) {
+        this.response = given()
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .multiPart("request",
+                        mapToString(createUserUpdateRequestDto()),
+                        MediaType.APPLICATION_JSON_VALUE)
+                .request(Method.PUT, "/api/v1/users")
+                .then();
+    }
+
+    public void 회원탈퇴_요청(final String token) {
+        this.response = given()
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .request(Method.DELETE, "/api/v1/users")
+                .then();
+    }
+}

--- a/src/test/java/org/ahpuh/surf/common/mapper/DtoObjectMapper.java
+++ b/src/test/java/org/ahpuh/surf/common/mapper/DtoObjectMapper.java
@@ -1,0 +1,27 @@
+package org.ahpuh.surf.common.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class DtoObjectMapper {
+
+    private final static ObjectMapper objectMapper = new ObjectMapper();
+
+    public static <T> String mapToString(final T dto) {
+        try {
+            return objectMapper.writeValueAsString(dto);
+        } catch (final JsonProcessingException e) {
+            e.printStackTrace();
+            return e.getMessage();
+        }
+    }
+
+    public static <T> byte[] mapToByte(final T dto) {
+        try {
+            return objectMapper.writeValueAsBytes(dto);
+        } catch (final JsonProcessingException e) {
+            e.printStackTrace();
+            return new byte[0];
+        }
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #175 

> User 도메인에 해당하는 인수테스트를 작성합니다.

## 📌 구현 내용

- [x] TUser fixture 생성
- [x] User 인수테스트 작성

## ✅ PR 포인트

- API의 given, when, then을 명확히 전달하기 위해 인수테스트 메소드명을 한글로 작성.
- 명확한 행위 명시를 위해 fixture 클래스를 만들어 method chaining 사용.