### PR TITLE
Jacoco, RestDocs 설정 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ out/
 ### Gradle ###
 .gradle
 build/
+
+### RestDocs ###
+src/main/resources/static/docs/**

--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,10 @@ task copyDocument(type: Copy) {
     into file("src/main/resources/static/docs")
 }
 
+jacoco {
+    toolVersion = '0.8.7'
+}
+
 jacocoTestReport {
     finalizedBy 'jacocoTestCoverageVerification'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,21 @@ jacoco {
 }
 
 jacocoTestReport {
+    reports {
+        html.enabled true
+        xml.enabled false
+        csv.enabled false
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it,
+                    exclude: [
+                            "**/SurfApplication*",
+                            "**/S3ServiceImpl*"
+                    ])
+        }))
+    }
     finalizedBy 'jacocoTestCoverageVerification'
 }
 
@@ -130,7 +145,10 @@ jacocoTestCoverageVerification {
                 minimum = 0.80
             }
 
-            excludes = []
+            excludes = [
+                    '**.SurfApplication*',
+                    '**.S3ServiceImpl*'
+            ]
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,6 @@ compileQuerydsl {
 //  QueryDsl 설정 끝
 
 test {
-    outputs.dir snippetsDir
     useJUnitPlatform()
     finalizedBy 'jacocoTestReport'
 }
@@ -98,6 +97,7 @@ test {
 asciidoctor {
     dependsOn test
     inputs.dir snippetsDir
+    finalizedBy 'copyDocument'
 }
 
 asciidoctor.doFirst {
@@ -105,7 +105,7 @@ asciidoctor.doFirst {
 }
 
 task copyDocument(type: Copy) {
-    dependsOn asciidoctor
+    dependsOn('asciidoctor')
     from file("build/docs/asciidoc")
     into file("src/main/resources/static/docs")
 }

--- a/src/docs/asciidoc/category.adoc
+++ b/src/docs/asciidoc/category.adoc
@@ -1,8 +1,12 @@
-:toc: left
-:toclevels: 2
-:sectlinks:
 ifndef::snippets[]
+:snippets: ./build/generated-snippets
 endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
 
 == Category (카테고리)
 

--- a/src/docs/asciidoc/follow.adoc
+++ b/src/docs/asciidoc/follow.adoc
@@ -1,8 +1,12 @@
-:toc: left
-:toclevels: 2
-:sectlinks:
 ifndef::snippets[]
+:snippets: ./build/generated-snippets
 endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
 
 == Follow (팔로우)
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,16 +1,49 @@
-ifndef::snippets[]
-:snippets: ../../../build/generated-snippets
-endif::[]
-:doctype: book
-:icons: font
-:source-highlighter: highlightjs
-:toc: left
-:toclevels: 4
+== Surf Application [API 문서]
 
-== Surf API
+=== link:user.html[유저 API]
 
-include::user.adoc[]
-include::category.adoc[]
-include::post.adoc[]
-include::follow.adoc[]
-include::like.adoc[]
+    회원 가입
+    로그인
+    유저 정보 조회
+    유저 정보 수정_프로필 이미지 첨부 O
+    유저 정보 수정_프로필 이미지 첨부 X
+    유저 삭제
+
+=== link:category.html[카테고리 API]
+
+    카테고리 생성
+    나의 카테고리 전체 조회
+    해당 유저의 카테고리 정보 조회
+    나의 카테고리 정보 수정
+    나의 카테고리 삭제
+
+=== link:post.html[게시글 API]
+
+    게시글 생성_파일 첨부 O
+    게시글 생성_파일 첨부 X
+    해당 게시글 정보 조회
+    나의 게시글 정보 수정_파일 첨부 O
+    나의 게시글 정보 수정_파일 첨부 X
+    나의 카테고리 삭제
+    즐겨찾기 추가
+    즐겨찾기 삭제
+    내 한달 게시글 정보 조회
+    해당 카테고리의 최신 게시글 점수 조회
+    해당 유저의 일년치 게시글 개수 조회
+    해당 유저의 카테고리별 게시글 점수 조회
+    전체 최신 게시글 둘러보기
+    내가 팔로잉한 유저들의 전체 게시글 둘러보기
+    해당 유저의 모든 게시글 정보 조회
+    해당 카테고리의 모든 게시글 정보 조회
+
+=== link:follow.html[팔로우 API]
+
+    팔로우
+    언팔로우
+    해당 유저의 팔로워 정보 전체 조회
+    해당 유저가 팔로잉한 유저 정보 전체 조회
+
+=== link:like.html[좋아요 API]
+
+    좋아요
+    좋아요 취소

--- a/src/docs/asciidoc/like.adoc
+++ b/src/docs/asciidoc/like.adoc
@@ -1,8 +1,12 @@
-:toc: left
-:toclevels: 2
-:sectlinks:
 ifndef::snippets[]
+:snippets: ./build/generated-snippets
 endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
 
 == Like (좋아요)
 

--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -1,8 +1,12 @@
-:toc: left
-:toclevels: 2
-:sectlinks:
 ifndef::snippets[]
+:snippets: ./build/generated-snippets
 endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
 
 == Post (게시글)
 

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -1,8 +1,12 @@
-:toc: left
-:toclevels: 2
-:sectlinks:
 ifndef::snippets[]
+:snippets: ./build/generated-snippets
 endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
 
 == User (유저)
 


### PR DESCRIPTION
## 📄 Description

- close : #181 

> - jacoco 버전을 명시합니다.
> - jacoco reports에서 제외할 클래스를 설정합니다.
> - asciidoctor task 실행시 resources/static/docs 위치에 html 문서를 생성하도록 설정합니다.

## 📌 구현 내용

- [x] Jacoco 설정 수정
- [x] RestDocs 설정 수정

## ✅ PR 포인트

### 1. Jacoco 설정에서 exclude 파일 설정시 주의할점
- `jacocoTestReport`에서 리포트 exclude 파일을 설정할때는 경로를 명시해줘야 합니다.
  ```groovy
  jacocoTestReport {
      ... 생략
  
      afterEvaluate {
          classDirectories.setFrom(files(classDirectories.files.collect {
              fileTree(dir: it,
                    exclude: [
  
                        // `org/surf/Application.class` 처럼 경로를 '/'를 사용하여 명시 ('*' 사용가능)
                        "**/SurfApplication*"
                    ])
          }))
      }
      finalizedBy 'jacocoTestCoverageVerification'
  }
  ```
- `jacocoTestCoverageVerification`에서 테스트 커버리지 exclude 파일을 설정할때는 패키지 + 클래스를 명시해줘야 합니다.
  ```groovy
  jacocoTestCoverageVerification {
      violationRules {
          rule {
              ... 생략
  
              excludes = [
                      // `org.surf.Application.class` 처럼 패키지 + 클래스 명시 ('*' 사용가능)
                      '**.SurfApplication*'
              ]
          }
      }
  }
  ```
### 2. RestDocs 설정 변경사항
- asciidoctor Task 실행시 `src/main/resources/static/docs`에 html 파일 생성
- asciidoc 파일에서 snippets 경로를 절대경로로 인식하는 문제가 있어서 절대경로에 맞게 변경
  - `:snippets: ./build/generated-snippets`
- `index.adoc`에서 생성된 html 파일들을 참조하도록 변경
  - 문서의 가독성 증가를 위함