### PR TITLE
Category 도메인 인수테스트 작성

### DIFF
--- a/src/test/java/org/ahpuh/surf/acceptance/category/CategoryControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/category/CategoryControllerTest.java
@@ -1,0 +1,177 @@
+package org.ahpuh.surf.acceptance.category;
+
+import org.ahpuh.surf.acceptance.AcceptanceTest;
+import org.ahpuh.surf.common.fixture.AfterLoginAction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.ahpuh.surf.common.fixture.TUser.USER_1;
+import static org.hamcrest.Matchers.is;
+
+public class CategoryControllerTest extends AcceptanceTest {
+
+    @DisplayName("카테고리 생성")
+    @Nested
+    class 카테고리_생성 {
+
+        @Test
+        void 카테고리_생성_성공() {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료();
+
+            // When
+            action.카테고리_생성_요청();
+
+            // Then
+            USER_1.response.statusCode(201);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = "카테고리이름은최대30글자까지입니다.이것은31글자이구요..")
+        void 카테고리명_최소1_최데30자_실패(final String categoryName) {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료();
+
+            // When
+            action.카테고리_생성_요청_name(categoryName);
+
+            // Then
+            USER_1.response.statusCode(400);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "#",
+                "#G00000",
+                "#GGGGGG",
+                "#0000000",
+                "000000",
+                "잘못된색깔코드"})
+        void 카테고리_색깔코드_실패(final String colorCode) {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료();
+
+            // When
+            action.카테고리_생성_요청_colorCode(colorCode);
+
+            // Then
+            USER_1.response.statusCode(400);
+        }
+    }
+
+    @DisplayName("카테고리 수정")
+    @Nested
+    class 카테고리_수정 {
+
+        @Test
+        void 카테고리_수정_성공() {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료().카테고리_생성_완료();
+
+            // When
+            action.카테고리_수정_요청();
+
+            // Then
+            USER_1.response.statusCode(200);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = "카테고리이름은최대30글자까지입니다.이것은31글자이구요..")
+        void 카테고리명_최소1_최데30자_실패(final String categoryName) {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료().카테고리_생성_완료();
+
+            // When
+            action.카테고리_수정_요청_name(categoryName);
+
+            // Then
+            USER_1.response.statusCode(400);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "#",
+                "#G00000",
+                "#GGGGGG",
+                "#0000000",
+                "000000",
+                "잘못된색깔코드"})
+        void 카테고리_색깔코드_실패(final String colorCode) {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료().카테고리_생성_완료();
+
+            // When
+            action.카테고리_수정_요청_colorCode(colorCode);
+
+            // Then
+            USER_1.response.statusCode(400);
+        }
+    }
+
+    @DisplayName("카테고리 삭제")
+    @Nested
+    class 카테고리_삭제 {
+
+        @Test
+        void 카테고리_삭제_성공() {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료().카테고리_생성_완료();
+
+            // When
+            action.카테고리_삭제_요청();
+
+            // Then
+            USER_1.response.statusCode(204);
+        }
+    }
+
+    @DisplayName("내 모든 카테고리 조회")
+    @Nested
+    class 내_모든_카테고리_조회 {
+
+        @Test
+        void 내_모든_카테고리_조회_성공() {
+            // Given : 카테고리 2개 생성
+            final AfterLoginAction action = USER_1.로그인_완료()
+                    .카테고리_생성_완료()
+                    .카테고리_생성_완료();
+
+            // When
+            action.내_모든_카테고리_조회_요청();
+
+            // Then
+            USER_1.response.statusCode(200)
+                    .body("size()", is(2));
+        }
+    }
+
+    @DisplayName("내 모든 카테고리 각각의 게시글 개수 및 평균점수 조회")
+    @Nested
+    class 내_모든_카테고리_각각의_게시글_개수_및_평균점수_조회 {
+
+        @Test
+        void 내_모든_카테고리_각각의_게시글_개수_및_평균점수_조회_성공() {
+            // Given
+            final AfterLoginAction action = USER_1.로그인_완료().카테고리_생성_완료()
+                    .게시글_생성_완료(100)
+                    .게시글_생성_완료(90);
+
+            // When
+            action.내_모든_카테고리_각각의_게시글_개수_및_평균점수_조회();
+
+            // Then
+            USER_1.response.statusCode(200)
+                    .body("size()", is(1))
+                    .body("[0].postCount", is(2))
+                    .body("[0].averageScore", is(95));
+        }
+    }
+}

--- a/src/test/java/org/ahpuh/surf/common/factory/MockPostFactory.java
+++ b/src/test/java/org/ahpuh/surf/common/factory/MockPostFactory.java
@@ -64,6 +64,15 @@ public class MockPostFactory {
                 .build();
     }
 
+    public static PostRequestDto createMockPostRequestDtoWithScore(final int score) {
+        return PostRequestDto.builder()
+                .categoryId(1L)
+                .selectedDate(LocalDate.now().toString())
+                .content("content")
+                .score(score)
+                .build();
+    }
+
     public static PostRequestDto createMockPostUpdateRequestDto(final Long categoryId) {
         return PostRequestDto.builder()
                 .categoryId(categoryId)

--- a/src/test/java/org/ahpuh/surf/common/fixture/AfterLoginAction.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/AfterLoginAction.java
@@ -1,10 +1,76 @@
 package org.ahpuh.surf.common.fixture;
 
+import java.util.Objects;
+
 public class AfterLoginAction {
 
     public final TUser user;
+    private CategoryAction categoryAction;
+    private PostAction postAction;
 
     AfterLoginAction(final TUser user) {
         this.user = user;
+        categoryAction = null;
+        postAction = null;
+    }
+
+    public void 카테고리_생성_요청() {
+        categoryAction().카테고리_생성_요청();
+    }
+
+    public void 카테고리_생성_요청_name(final String categoryName) {
+        categoryAction().카테고리_생성_요청_name(categoryName);
+    }
+
+    public void 카테고리_생성_요청_colorCode(final String colorCode) {
+        categoryAction().카테고리_생성_요청_colorCode(colorCode);
+    }
+
+    public AfterLoginAction 카테고리_생성_완료() {
+        categoryAction().카테고리_생성_완료();
+        return this;
+    }
+
+    public void 카테고리_수정_요청() {
+        categoryAction().카테고리_수정_요청();
+    }
+
+    public void 카테고리_수정_요청_name(final String categoryName) {
+        categoryAction().카테고리_수정_요청_name(categoryName);
+    }
+
+    public void 카테고리_수정_요청_colorCode(final String colorCode) {
+        categoryAction().카테고리_수정_요청_colorCode(colorCode);
+    }
+
+    public void 카테고리_삭제_요청() {
+        categoryAction().카테고리_삭제_요청();
+    }
+
+    public void 내_모든_카테고리_조회_요청() {
+        categoryAction().내_모든_카테고리_조회_요청();
+    }
+
+    public void 내_모든_카테고리_각각의_게시글_개수_및_평균점수_조회() {
+        categoryAction().내_모든_카테고리_각각의_게시글_개수_및_평균점수_조회();
+    }
+
+    public AfterLoginAction 게시글_생성_완료(final int postScore) {
+        postAction().게시글_생성_완료(postScore);
+        return this;
+    }
+
+    private CategoryAction categoryAction() {
+        if (Objects.isNull(categoryAction)) {
+            categoryAction = new CategoryAction(user);
+        }
+        return categoryAction;
+    }
+
+    private PostAction postAction() {
+        if (Objects.isNull(postAction)) {
+            postAction = new PostAction(user);
+        }
+        return postAction;
     }
 }

--- a/src/test/java/org/ahpuh/surf/common/fixture/CategoryAction.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/CategoryAction.java
@@ -1,0 +1,104 @@
+package org.ahpuh.surf.common.fixture;
+
+import io.restassured.http.Method;
+import org.ahpuh.surf.category.dto.request.CategoryCreateRequestDto;
+import org.ahpuh.surf.category.dto.request.CategoryUpdateRequestDto;
+import org.apache.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static io.restassured.RestAssured.given;
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategoryCreateRequestDto;
+import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategoryUpdateRequestDto;
+
+public class CategoryAction {
+
+    private final TUser user;
+
+    public CategoryAction(final TUser user) {
+        this.user = user;
+    }
+
+    public void 카테고리_생성_요청() {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createMockCategoryCreateRequestDto())
+                .request(Method.POST, "/api/v1/categories")
+                .then();
+    }
+
+    public void 카테고리_생성_요청_name(final String categoryName) {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new CategoryCreateRequestDto(categoryName, "#000000"))
+                .request(Method.POST, "/api/v1/categories")
+                .then();
+    }
+
+    public void 카테고리_생성_요청_colorCode(final String colorCode) {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new CategoryCreateRequestDto("categoryName", colorCode))
+                .request(Method.POST, "/api/v1/categories")
+                .then();
+    }
+
+    public void 카테고리_생성_완료() {
+        user.response = given().header(HttpHeaders.AUTHORIZATION, user.token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createMockCategoryCreateRequestDto())
+                .request(Method.POST, "/api/v1/categories")
+                .then();
+    }
+
+    public void 카테고리_수정_요청() {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createMockCategoryUpdateRequestDto())
+                .request(Method.PUT, "/api/v1/categories/{categoryId}", 1L)
+                .then();
+    }
+
+    public void 카테고리_수정_요청_name(final String categoryName) {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new CategoryUpdateRequestDto(categoryName, true, "#000000"))
+                .request(Method.PUT, "/api/v1/categories/{categoryId}", 1L)
+                .then();
+    }
+
+    public void 카테고리_수정_요청_colorCode(final String colorCode) {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(new CategoryUpdateRequestDto("categoryName", true, colorCode))
+                .request(Method.PUT, "/api/v1/categories/{categoryId}", 1L)
+                .then();
+    }
+
+    public void 카테고리_삭제_요청() {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .request(Method.DELETE, "/api/v1/categories/{categoryId}", 1L)
+                .then();
+    }
+
+    public void 내_모든_카테고리_조회_요청() {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .request(Method.GET, "/api/v1/categories")
+                .then();
+    }
+
+    public void 내_모든_카테고리_각각의_게시글_개수_및_평균점수_조회() {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .param("userId", user.userId)
+                .request(Method.GET, "/api/v1/categories/dashboard")
+                .then();
+    }
+}

--- a/src/test/java/org/ahpuh/surf/common/fixture/PostAction.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/PostAction.java
@@ -1,0 +1,28 @@
+package org.ahpuh.surf.common.fixture;
+
+import io.restassured.http.Method;
+import org.apache.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import static io.restassured.RestAssured.given;
+import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPostRequestDtoWithScore;
+import static org.ahpuh.surf.common.mapper.DtoObjectMapper.mapToString;
+
+public class PostAction {
+
+    private final TUser user;
+
+    public PostAction(final TUser user) {
+        this.user = user;
+    }
+
+    public void 게시글_생성_완료(final int postScore) {
+        this.user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .multiPart("request",
+                        mapToString(createMockPostRequestDtoWithScore(postScore)),
+                        MediaType.APPLICATION_JSON_VALUE)
+                .request(Method.POST, "/api/v1/posts")
+                .then();
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #187 

> Category 도메인에 해당하는 인수테스트를 작성합니다.

## 📌 구현 내용

- [x] Category 도메인 인수테스트 작성
- [x] AfterLoginAction class 구현 (User Login 이후 Action을 메소드 체이닝으로 구현)
- [x] CategoryAction 구현

## ✅ PR 포인트

- `AfterLoginAction` 클래스를 구현했습니다.
  - User가 로그인을 한 이후에 할 수 있는 행위들이 굉장히 많습니다.  
    이 행위들을 하나의 클래스안에 다 몰아넣으면 가독성이 떨어지기 때문에, 도메인에 맞게 Action 클래스를 구분했습니다.
  - 그리고 각각의 Action들을 하나의 메소드 체이닝으로 표현할 수 있게 `AfterLoginAction` 클래스를 중간에 놓았습니다.
  - `[AfterLoginAction 다이어그램]`
  ![image](https://user-images.githubusercontent.com/60170616/159242779-1651ce72-5068-45f4-ac7e-0048663b585f.png)
