### PR TITLE
인수테스트 리팩토링

### DIFF
--- a/src/test/java/org/ahpuh/surf/acceptance/category/CategoryControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/category/CategoryControllerTest.java
@@ -33,7 +33,7 @@ public class CategoryControllerTest extends AcceptanceTest {
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = "카테고리이름은최대30글자까지입니다.이것은31글자이구요..")
-        void 카테고리명_최소1_최데30자_실패(final String categoryName) {
+        void 카테고리명_최소1_최대30자_실패(final String categoryName) {
             // Given
             final AfterLoginAction action = USER_1.로그인_완료();
 
@@ -84,7 +84,7 @@ public class CategoryControllerTest extends AcceptanceTest {
         @ParameterizedTest
         @NullAndEmptySource
         @ValueSource(strings = "카테고리이름은최대30글자까지입니다.이것은31글자이구요..")
-        void 카테고리명_최소1_최데30자_실패(final String categoryName) {
+        void 카테고리명_최소1_최대30자_실패(final String categoryName) {
             // Given
             final AfterLoginAction action = USER_1.로그인_완료().카테고리_생성_완료();
 

--- a/src/test/java/org/ahpuh/surf/acceptance/user/UserControllerTest.java
+++ b/src/test/java/org/ahpuh/surf/acceptance/user/UserControllerTest.java
@@ -1,6 +1,7 @@
 package org.ahpuh.surf.acceptance.user;
 
 import org.ahpuh.surf.acceptance.AcceptanceTest;
+import org.ahpuh.surf.common.fixture.AfterLoginAction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -118,10 +119,10 @@ public class UserControllerTest extends AcceptanceTest {
         @Test
         void 유저정보_조회_성공() {
             // Given
-            USER_1.로그인_완료();
+            final AfterLoginAction action = USER_1.로그인_완료();
 
             // When
-            USER_1.유저조회_요청(1L);
+            action.유저조회_요청(1L);
 
             // Then
             USER_1.response.statusCode(200);
@@ -130,11 +131,11 @@ public class UserControllerTest extends AcceptanceTest {
         @Test
         void 존재하지_않는_유저_아이디_실패() {
             // Given
-            USER_1.로그인_완료();
+            final AfterLoginAction action = USER_1.로그인_완료();
             final Long invalidUserId = 2L;
 
             // When
-            USER_1.유저조회_요청(invalidUserId);
+            action.유저조회_요청(invalidUserId);
 
             // Then
             USER_1.response.statusCode(404);
@@ -148,11 +149,11 @@ public class UserControllerTest extends AcceptanceTest {
         @Test
         void 유저정보_수정_프로필이미지_첨부O_성공() {
             // Given
-            USER_1.로그인_완료();
+            final AfterLoginAction action = USER_1.로그인_완료();
             final File profileImage = createImageFile();
 
             // When
-            USER_1.유저정보_수정_요청_With_File(profileImage);
+            action.유저정보_수정_요청_With_File(profileImage);
 
             // Then
             USER_1.response.statusCode(200);
@@ -161,10 +162,10 @@ public class UserControllerTest extends AcceptanceTest {
         @Test
         void 유저정보_수정_프로필이미지_첨부X_성공() {
             // Given
-            USER_1.로그인_완료();
+            final AfterLoginAction action = USER_1.로그인_완료();
 
             // When
-            USER_1.유저정보_수정_요청_No_File();
+            action.유저정보_수정_요청_No_File();
 
             // Then
             USER_1.response.statusCode(200);
@@ -173,10 +174,10 @@ public class UserControllerTest extends AcceptanceTest {
         @Test
         void 유저정보_수정_잘못된_File_실패() {
             // Given
-            USER_1.로그인_완료();
+            final AfterLoginAction action = USER_1.로그인_완료();
 
             // When
-            USER_1.유저정보_수정_요청_With_File(invalidFile());
+            action.유저정보_수정_요청_With_File(invalidFile());
 
             // Then
             USER_1.response.statusCode(400);
@@ -190,10 +191,10 @@ public class UserControllerTest extends AcceptanceTest {
         @Test
         void 유저삭제_성공() {
             // Given
-            USER_1.로그인_완료();
+            final AfterLoginAction action = USER_1.로그인_완료();
 
             // When
-            USER_1.회원탈퇴_요청();
+            action.회원탈퇴_요청();
 
             // Then
             USER_1.response.statusCode(204);

--- a/src/test/java/org/ahpuh/surf/common/fixture/AfterLoginAction.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/AfterLoginAction.java
@@ -45,7 +45,7 @@ public class AfterLoginAction {
     }
 
     public AfterLoginAction 카테고리_생성_완료() {
-        categoryAction().카테고리_생성_완료();
+        categoryAction().카테고리_생성_요청();
         return this;
     }
 

--- a/src/test/java/org/ahpuh/surf/common/fixture/AfterLoginAction.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/AfterLoginAction.java
@@ -1,10 +1,12 @@
 package org.ahpuh.surf.common.fixture;
 
+import java.io.File;
 import java.util.Objects;
 
 public class AfterLoginAction {
 
     public final TUser user;
+    private UserAction userAction;
     private CategoryAction categoryAction;
     private PostAction postAction;
 
@@ -12,6 +14,22 @@ public class AfterLoginAction {
         this.user = user;
         categoryAction = null;
         postAction = null;
+    }
+
+    public void 유저조회_요청(final Long userId) {
+        userAction().유저조회_요청(userId);
+    }
+
+    public void 유저정보_수정_요청_With_File(final File file) {
+        userAction().유저정보_수정_요청_With_File(file);
+    }
+
+    public void 유저정보_수정_요청_No_File() {
+        userAction().유저정보_수정_요청_No_File();
+    }
+
+    public void 회원탈퇴_요청() {
+        userAction().회원탈퇴_요청();
     }
 
     public void 카테고리_생성_요청() {
@@ -58,6 +76,13 @@ public class AfterLoginAction {
     public AfterLoginAction 게시글_생성_완료(final int postScore) {
         postAction().게시글_생성_완료(postScore);
         return this;
+    }
+
+    private UserAction userAction() {
+        if (Objects.isNull(userAction)) {
+            userAction = new UserAction(user);
+        }
+        return userAction;
     }
 
     private CategoryAction categoryAction() {

--- a/src/test/java/org/ahpuh/surf/common/fixture/CategoryAction.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/CategoryAction.java
@@ -45,14 +45,6 @@ public class CategoryAction {
                 .then();
     }
 
-    public void 카테고리_생성_완료() {
-        user.response = given().header(HttpHeaders.AUTHORIZATION, user.token)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(createMockCategoryCreateRequestDto())
-                .request(Method.POST, "/api/v1/categories")
-                .then();
-    }
-
     public void 카테고리_수정_요청() {
         this.user.response = given()
                 .header(HttpHeaders.AUTHORIZATION, user.token)

--- a/src/test/java/org/ahpuh/surf/common/fixture/TUser.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/TUser.java
@@ -3,14 +3,10 @@ package org.ahpuh.surf.common.fixture;
 import io.restassured.http.Method;
 import io.restassured.response.ValidatableResponse;
 import org.ahpuh.surf.user.dto.response.UserLoginResponseDto;
-import org.apache.http.HttpHeaders;
 import org.springframework.http.MediaType;
-
-import java.io.File;
 
 import static io.restassured.RestAssured.given;
 import static org.ahpuh.surf.common.factory.MockUserFactory.*;
-import static org.ahpuh.surf.common.mapper.DtoObjectMapper.mapToString;
 
 public enum TUser {
     USER_1(1L, "user1"),
@@ -81,53 +77,11 @@ public enum TUser {
     }
 
     public AfterLoginAction 로그인_완료() {
-        given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(createUserJoinRequestDtoWithEmail(this.email))
-                .request(Method.POST, "/api/v1/users");
-        this.token = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(createUserLoginRequestDto(this.email))
-                .request(Method.POST, "/api/v1/users/login")
-                .then().statusCode(200)
+        회원가입_완료();
+        로그인_요청();
+        this.token = this.response.statusCode(200)
                 .extract().as(UserLoginResponseDto.class)
                 .getToken();
         return new AfterLoginAction(this);
-    }
-
-    public void 유저조회_요청(final Long userId) {
-        this.response = given()
-                .header(HttpHeaders.AUTHORIZATION, this.token)
-                .request(Method.GET, "/api/v1/users/{userId}", userId)
-                .then();
-    }
-
-    public void 유저정보_수정_요청_With_File(final File file) {
-        this.response = given()
-                .header(HttpHeaders.AUTHORIZATION, this.token)
-                .multiPart("file",
-                        file,
-                        MediaType.MULTIPART_FORM_DATA_VALUE)
-                .multiPart("request",
-                        mapToString(createUserUpdateRequestDto()),
-                        MediaType.APPLICATION_JSON_VALUE)
-                .request(Method.PUT, "/api/v1/users")
-                .then();
-    }
-
-    public void 유저정보_수정_요청_No_File() {
-        this.response = given()
-                .header(HttpHeaders.AUTHORIZATION, this.token)
-                .multiPart("request",
-                        mapToString(createUserUpdateRequestDto()),
-                        MediaType.APPLICATION_JSON_VALUE)
-                .request(Method.PUT, "/api/v1/users")
-                .then();
-    }
-
-    public void 회원탈퇴_요청() {
-        this.response = given()
-                .header(HttpHeaders.AUTHORIZATION, this.token)
-                .request(Method.DELETE, "/api/v1/users")
-                .then();
     }
 }

--- a/src/test/java/org/ahpuh/surf/common/fixture/TUser.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/TUser.java
@@ -52,9 +52,7 @@ public enum TUser {
     }
 
     public void 회원가입_완료() {
-        given().contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(createUserJoinRequestDtoWithEmail(this.email))
-                .request(Method.POST, "/api/v1/users");
+        회원가입_요청();
     }
 
     public void 회원가입_하지_않음() {

--- a/src/test/java/org/ahpuh/surf/common/fixture/UserAction.java
+++ b/src/test/java/org/ahpuh/surf/common/fixture/UserAction.java
@@ -1,0 +1,57 @@
+package org.ahpuh.surf.common.fixture;
+
+import io.restassured.http.Method;
+import org.apache.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.io.File;
+
+import static io.restassured.RestAssured.given;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createUserUpdateRequestDto;
+import static org.ahpuh.surf.common.mapper.DtoObjectMapper.mapToString;
+
+public class UserAction {
+
+    private final TUser user;
+
+    public UserAction(final TUser user) {
+        this.user = user;
+    }
+
+    public void 유저조회_요청(final Long userId) {
+        user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .request(Method.GET, "/api/v1/users/{userId}", userId)
+                .then();
+    }
+
+    public void 유저정보_수정_요청_With_File(final File file) {
+        user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .multiPart("file",
+                        file,
+                        MediaType.MULTIPART_FORM_DATA_VALUE)
+                .multiPart("request",
+                        mapToString(createUserUpdateRequestDto()),
+                        MediaType.APPLICATION_JSON_VALUE)
+                .request(Method.PUT, "/api/v1/users")
+                .then();
+    }
+
+    public void 유저정보_수정_요청_No_File() {
+        user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .multiPart("request",
+                        mapToString(createUserUpdateRequestDto()),
+                        MediaType.APPLICATION_JSON_VALUE)
+                .request(Method.PUT, "/api/v1/users")
+                .then();
+    }
+
+    public void 회원탈퇴_요청() {
+        user.response = given()
+                .header(HttpHeaders.AUTHORIZATION, user.token)
+                .request(Method.DELETE, "/api/v1/users")
+                .then();
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #193 

> - User도 AfterLoginAction 클래스로 메소드를 관리하게 수정합니다.
> - 재활용 가능한 메소드를 재활용하도록 수정합니다.
>   - ex) 로그인_완료() 메소드를 새로운 요청을 보내지 않고 로그인_요청() 메소드를 재활용함.

## 📌 구현 내용

- [x] UserAction 클래스 생성
- [x] User 인수테스트를 LoginAfterAction을 사용하도록 변경
- [x] *완료 메소드를 내부 메소드를 활용하도록 변경
- [x] 오타 수정
