### PR TITLE
조회 쿼리 성능 문제 이슈

### DIFF
--- a/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepositoryImpl.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepositoryImpl.java
@@ -11,7 +11,6 @@ import org.ahpuh.surf.user.domain.User;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -67,7 +66,7 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                 .where(post.user.userId.eq(userId)
                         .and(post.selectedDate.goe(startDate))
                         .and(post.selectedDate.loe(endDate)))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .fetch();
     }
 
@@ -133,13 +132,13 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                 .from(post)
                 .leftJoin(follow).on(follow.source.userId.eq(userId).and(follow.target.userId.eq(post.user.userId)))
                 .leftJoin(like).on(like.user.userId.eq(userId).and(post.postId.eq(like.post.postId)))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }
 
     @Override
-    public List<RecentPostResponseDto> findAllRecentPostByCursor(final Long userId, final LocalDate selectedDate, final LocalDateTime createdAt, final Pageable page) {
+    public List<RecentPostResponseDto> findAllRecentPostByCursor(final Long userId, final Long cursorPostId, final LocalDate selectedDate, final Pageable page) {
         return queryFactory
                 .select(new QRecentPostResponseDto(
                         post.user.userId.as("userId"),
@@ -161,8 +160,8 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                 .leftJoin(follow).on(follow.source.userId.eq(userId).and(follow.target.userId.eq(post.user.userId)))
                 .leftJoin(like).on(like.user.userId.eq(userId).and(post.postId.eq(like.post.postId)))
                 .where((post.selectedDate.lt(selectedDate))
-                        .or(post.selectedDate.eq(selectedDate).and(post.createdAt.lt(createdAt))))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                        .or(post.selectedDate.eq(selectedDate).and(post.postId.lt(cursorPostId))))
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }
@@ -189,13 +188,13 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                 .leftJoin(follow).on(follow.source.userId.eq(userId))
                 .leftJoin(like).on(like.user.userId.eq(userId).and(post.postId.eq(like.post.postId)))
                 .where(follow.source.userId.eq(userId).and(follow.target.userId.eq(post.user.userId)))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }
 
     @Override
-    public List<ExploreResponseDto> findFollowingPostsByCursor(final Long userId, final LocalDate selectedDate, final LocalDateTime createdAt, final Pageable page) {
+    public List<ExploreResponseDto> findFollowingPostsByCursor(final Long userId, final Long cursorPostId, final LocalDate selectedDate, final Pageable page) {
         return queryFactory
                 .select(new QExploreResponseDto(
                         post.user.userId.as("userId"),
@@ -220,9 +219,9 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                         .and(post.selectedDate.lt(selectedDate))
                         .or(follow.source.userId.eq(userId)
                                 .and(follow.target.userId.eq(post.user.userId))
-                                .and(post.createdAt.lt(createdAt))
+                                .and(post.postId.lt(cursorPostId))
                                 .and(post.selectedDate.eq(selectedDate))))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }
@@ -244,13 +243,13 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                 .from(post)
                 .leftJoin(like).on(like.user.userId.eq(userId).and(post.postId.eq(like.post.postId)))
                 .where(post.user.userId.eq(postUserId))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }
 
     @Override
-    public List<AllPostResponseDto> findAllPostOfUserByCursor(final Long userId, final Long postUserId, final LocalDate selectedDate, final LocalDateTime createdAt, final Pageable page) {
+    public List<AllPostResponseDto> findAllPostOfUserByCursor(final Long userId, final Long postUserId, final Long cursorPostId, final LocalDate selectedDate, final Pageable page) {
         return queryFactory
                 .select(new QAllPostResponseDto(
                         post.category.name.as("categoryName"),
@@ -269,8 +268,8 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                         .and(post.selectedDate.lt(selectedDate))
                         .or(post.user.userId.eq(postUserId)
                                 .and(post.selectedDate.eq(selectedDate))
-                                .and(post.createdAt.lt(createdAt))))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                                .and(post.postId.lt(cursorPostId))))
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }
@@ -292,13 +291,13 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                 .from(post)
                 .leftJoin(like).on(like.user.userId.eq(userId).and(post.postId.eq(like.post.postId)))
                 .where(post.category.categoryId.eq(categoryId))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }
 
     @Override
-    public List<AllPostResponseDto> findAllPostOfCategoryByCursor(final Long userId, final Long categoryId, final LocalDate selectedDate, final LocalDateTime createdAt, final Pageable page) {
+    public List<AllPostResponseDto> findAllPostOfCategoryByCursor(final Long userId, final Long categoryId, final Long cursorPostId, final LocalDate selectedDate, final Pageable page) {
         return queryFactory
                 .select(new QAllPostResponseDto(
                         post.category.name.as("categoryName"),
@@ -317,8 +316,8 @@ public class PostRepositoryImpl implements PostRepositoryQuerydsl {
                         .and(post.selectedDate.lt(selectedDate))
                         .or(post.category.categoryId.eq(categoryId)
                                 .and(post.selectedDate.eq(selectedDate))
-                                .and(post.createdAt.lt(createdAt))))
-                .orderBy(post.selectedDate.desc(), post.createdAt.desc())
+                                .and(post.postId.lt(cursorPostId))))
+                .orderBy(post.selectedDate.desc(), post.postId.desc())
                 .limit(page.getPageSize())
                 .fetch();
     }

--- a/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepositoryQuerydsl.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/repository/PostRepositoryQuerydsl.java
@@ -6,7 +6,6 @@ import org.ahpuh.surf.user.domain.User;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,18 +21,18 @@ public interface PostRepositoryQuerydsl {
 
     List<RecentPostResponseDto> findAllRecentPost(Long userId, Pageable page);
 
-    List<RecentPostResponseDto> findAllRecentPostByCursor(Long userId, LocalDate selectedDate, LocalDateTime createdAt, Pageable page);
+    List<RecentPostResponseDto> findAllRecentPostByCursor(Long userId, Long cursorPostId, LocalDate selectedDate, Pageable page);
 
     List<ExploreResponseDto> findFollowingPosts(Long userId, Pageable page);
 
-    List<ExploreResponseDto> findFollowingPostsByCursor(Long userId, LocalDate selectedDate, LocalDateTime createdAt, Pageable page);
+    List<ExploreResponseDto> findFollowingPostsByCursor(Long userId, Long cursorPostId, LocalDate selectedDate, Pageable page);
 
     List<AllPostResponseDto> findAllPostOfUser(Long userId, Long postUserId, Pageable page);
 
-    List<AllPostResponseDto> findAllPostOfUserByCursor(Long userId, Long postUserId, LocalDate selectedDate, LocalDateTime createdAt, Pageable page);
+    List<AllPostResponseDto> findAllPostOfUserByCursor(Long userId, Long postUserId, Long cursorPostId, LocalDate selectedDate, Pageable page);
 
     List<AllPostResponseDto> findAllPostOfCategory(Long userId, Long categoryId, Pageable page);
 
-    List<AllPostResponseDto> findAllPostOfCategoryByCursor(Long userId, Long categoryId, LocalDate selectedDate, LocalDateTime createdAt, Pageable page);
+    List<AllPostResponseDto> findAllPostOfCategoryByCursor(Long userId, Long categoryId, Long cursorPostId, LocalDate selectedDate, Pageable page);
 
 }

--- a/src/main/java/org/ahpuh/surf/post/service/PostService.java
+++ b/src/main/java/org/ahpuh/surf/post/service/PostService.java
@@ -136,7 +136,7 @@ public class PostService {
         final Post findPost = (cursorId == 0 ? null : getPost(cursorId));
         final List<RecentPostResponseDto> postDtos = Objects.isNull(findPost)
                 ? postRepository.findAllRecentPost(userId, PAGE)
-                : postRepository.findAllRecentPostByCursor(userId, findPost.getSelectedDate(), findPost.getCreatedAt(), PAGE);
+                : postRepository.findAllRecentPostByCursor(userId, cursorId, findPost.getSelectedDate(), PAGE);
 
         final boolean hasNext = hasNextCheck(postDtos);
         postDtos.forEach(RecentPostResponseDto::likeCheck);
@@ -148,7 +148,7 @@ public class PostService {
         final Post findPost = (cursorId == 0 ? null : getPost(cursorId));
         final List<ExploreResponseDto> exploreDtos = Objects.isNull(findPost)
                 ? postRepository.findFollowingPosts(userId, PAGE)
-                : postRepository.findFollowingPostsByCursor(userId, findPost.getSelectedDate(), findPost.getCreatedAt(), PAGE);
+                : postRepository.findFollowingPostsByCursor(userId, cursorId, findPost.getSelectedDate(), PAGE);
 
         final boolean hasNext = hasNextCheck(exploreDtos);
         exploreDtos.forEach(ExploreResponseDto::likeCheck);
@@ -160,7 +160,7 @@ public class PostService {
         final Post findPost = (cursorId == 0 ? null : getPost(cursorId));
         final List<AllPostResponseDto> postDtos = Objects.isNull(findPost)
                 ? postRepository.findAllPostOfUser(userId, postUserId, PAGE)
-                : postRepository.findAllPostOfUserByCursor(userId, postUserId, findPost.getSelectedDate(), findPost.getCreatedAt(), PAGE);
+                : postRepository.findAllPostOfUserByCursor(userId, postUserId, cursorId, findPost.getSelectedDate(), PAGE);
 
         final boolean hasNext = hasNextCheck(postDtos);
         postDtos.forEach(AllPostResponseDto::likeCheck);
@@ -172,7 +172,7 @@ public class PostService {
         final Post findPost = (cursorId == 0 ? null : getPost(cursorId));
         final List<AllPostResponseDto> postDtos = Objects.isNull(findPost)
                 ? postRepository.findAllPostOfCategory(userId, categoryId, PAGE)
-                : postRepository.findAllPostOfCategoryByCursor(userId, categoryId, findPost.getSelectedDate(), findPost.getCreatedAt(), PAGE);
+                : postRepository.findAllPostOfCategoryByCursor(userId, categoryId, cursorId, findPost.getSelectedDate(), PAGE);
 
         final boolean hasNext = hasNextCheck(postDtos);
         postDtos.forEach(AllPostResponseDto::likeCheck);

--- a/src/main/resources/db/migration/V2__set_index.sql
+++ b/src/main/resources/db/migration/V2__set_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX posts_selected_date_idx ON posts (selected_date);

--- a/src/test/java/org/ahpuh/surf/unit/post/domain/PostQueryDslTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/domain/PostQueryDslTest.java
@@ -19,7 +19,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -366,8 +365,8 @@ public class PostQueryDslTest {
                 // When
                 final List<RecentPostResponseDto> responseDtos = postRepository.findAllRecentPostByCursor(
                         userId,
+                        5L,
                         LocalDate.of(2022, 1, 3),
-                        LocalDateTime.of(2022, 1, 1, 1, 1),
                         PAGE_REQUEST);
 
                 // Then
@@ -536,8 +535,8 @@ public class PostQueryDslTest {
                 // When
                 final List<ExploreResponseDto> responseDtos = postRepository.findFollowingPostsByCursor(
                         userId2,
+                        5L,
                         LocalDate.of(2022, 1, 3),
-                        LocalDateTime.of(2022, 1, 1, 1, 1),
                         PAGE_REQUEST);
 
                 // Then
@@ -677,8 +676,8 @@ public class PostQueryDslTest {
                 final List<AllPostResponseDto> responseDtos = postRepository.findAllPostOfUserByCursor(
                         userId2,
                         userId1,
+                        5L,
                         LocalDate.of(2022, 1, 3),
-                        LocalDateTime.of(2022, 1, 1, 1, 1),
                         PAGE_REQUEST);
 
                 // Then
@@ -819,8 +818,8 @@ public class PostQueryDslTest {
                 final List<AllPostResponseDto> responseDtos = postRepository.findAllPostOfCategoryByCursor(
                         userId2,
                         categoryId1,
+                        5L,
                         LocalDate.of(2022, 1, 3),
-                        LocalDateTime.of(2022, 1, 1, 1, 1),
                         PAGE_REQUEST);
 
                 // Then

--- a/src/test/java/org/ahpuh/surf/unit/post/service/PostCursorPagingTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/service/PostCursorPagingTest.java
@@ -20,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -153,9 +152,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findAllRecentPostByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findAllRecentPostByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -167,7 +164,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findAllRecentPost(any(), any());
                 verify(postRepository, times(1))
-                        .findAllRecentPostByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findAllRecentPostByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(10))
                         .likeCheck();
                 assertAll("게시글 10개 조회, hasNext = true",
@@ -191,9 +188,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findAllRecentPostByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findAllRecentPostByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -205,7 +200,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findAllRecentPost(any(), any());
                 verify(postRepository, times(1))
-                        .findAllRecentPostByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findAllRecentPostByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(postCount))
                         .likeCheck();
                 assertAll("게시글 조회, hasNext = false",
@@ -348,9 +343,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findFollowingPostsByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findFollowingPostsByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -362,7 +355,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findFollowingPosts(any(), any());
                 verify(postRepository, times(1))
-                        .findFollowingPostsByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findFollowingPostsByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(10))
                         .likeCheck();
                 assertAll("게시글 10개 조회, hasNext = true",
@@ -386,9 +379,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findFollowingPostsByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findFollowingPostsByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -400,7 +391,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findFollowingPosts(any(), any());
                 verify(postRepository, times(1))
-                        .findFollowingPostsByCursor(anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findFollowingPostsByCursor(anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(postCount))
                         .likeCheck();
                 assertAll("게시글 조회, hasNext = false",
@@ -543,9 +534,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findAllPostOfUserByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findAllPostOfUserByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -557,7 +546,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findAllPostOfCategory(any(), any(), any());
                 verify(postRepository, times(1))
-                        .findAllPostOfUserByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findAllPostOfUserByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(10))
                         .likeCheck();
                 assertAll("게시글 10개 조회, hasNext = true",
@@ -581,9 +570,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findAllPostOfUserByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findAllPostOfUserByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -595,7 +582,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findAllPostOfCategory(any(), any(), any());
                 verify(postRepository, times(1))
-                        .findAllPostOfUserByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findAllPostOfUserByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(postCount))
                         .likeCheck();
                 assertAll("게시글 조회, hasNext = false",
@@ -738,9 +725,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findAllPostOfCategoryByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findAllPostOfCategoryByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -752,7 +737,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findAllPostOfCategory(any(), any(), any());
                 verify(postRepository, times(1))
-                        .findAllPostOfCategoryByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findAllPostOfCategoryByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(10))
                         .likeCheck();
                 assertAll("게시글 10개 조회, hasNext = true",
@@ -776,9 +761,7 @@ public class PostCursorPagingTest {
                         .willReturn(Optional.of(post));
                 given(post.getSelectedDate())
                         .willReturn(LocalDate.of(2022, 1, 1));
-                given(post.getCreatedAt())
-                        .willReturn(LocalDateTime.of(2022, 1, 1, 12, 12, 12));
-                given(postRepository.findAllPostOfCategoryByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class)))
+                given(postRepository.findAllPostOfCategoryByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class)))
                         .willReturn(responseDtos);
 
                 // When
@@ -790,7 +773,7 @@ public class PostCursorPagingTest {
                 verify(postRepository, times(0))
                         .findAllPostOfCategory(any(), any(), any());
                 verify(postRepository, times(1))
-                        .findAllPostOfCategoryByCursor(anyLong(), anyLong(), any(LocalDate.class), any(LocalDateTime.class), any(PageRequest.class));
+                        .findAllPostOfCategoryByCursor(anyLong(), anyLong(), anyLong(), any(LocalDate.class), any(PageRequest.class));
                 verify(postDto, times(postCount))
                         .likeCheck();
                 assertAll("게시글 조회, hasNext = false",


### PR DESCRIPTION
## 📄 Description

- close : #205 

> posts 테이블에 100만건의 데이터를 삽입 후 slow query를 확인했습니다.
> 무한 스크롤페이징 처리로 10개의 데이터씩 가져오는데 여기서 비효율적인 부분이 있었습니다.
> - 매번 모든 데이터(100만건)를 정렬 후 10개를 가져오는 문제
> - 인덱스를 못타는 문제

## 📌 구현 내용

- [x] 인덱스 생성
- [x] 쿼리 튜닝

## ✅ PR 포인트

- 문제를 확인한 부분의 쿼리입니다.
  - 무한 스크롤페이지 처리를 하여 원하는 데이터를 `10개`씩 가져옵니다.
  - 눈여겨볼 부분은 ORDER BY 조건을 `selected_date`와 `created_at`으로 설정한 부분입니다.
  ```sql
  SELECT
      ... 많아서 생략
  FROM
      posts post
  LEFT OUTER JOIN
      follow
          ON (
              follow.user_id=1
              AND follow.following_id=post.user_id
          ) 
  LEFT OUTER JOIN
      likes
          ON (
              likes.user_id=1
              AND post.post_id=likes.post_id
          )
  CROSS JOIN users
  CROSS JOIN categories
  WHERE
      post.is_deleted = 0
      AND post.user_id=users.user_id 
      AND post.category_id=categories.category_id 
  ORDER BY
      post.selected_date DESC,
      post.created_at DESC
  LIMIT 10;
  ```
- 먼저 Bulk Insert로 빠르게 100만 건의 데이터를 세팅했습니다.
![image](https://user-images.githubusercontent.com/60170616/160560096-4878242d-fc8c-4339-8ad0-3cfb59683aae.png)
- 가상 테이블을 생성하고, 전체 데이터를 sorting 하는 문제를 발견했습니다.
![image](https://user-images.githubusercontent.com/60170616/160562003-887f8f3e-1641-49f3-b19b-64330e4eb70a.png)
  - `using temporary` : 가상 테이블 생성
  - `using filesort` : 전체 정렬
- 10개의 데이터만 조회하는데, 100만건의 데이터를 전체 조회 후 10개만 가져오는 비효율적인 방식입니다.
  - 44.7초가 걸리는 상황;;
![image](https://user-images.githubusercontent.com/60170616/160562806-96824337-ad21-4fc7-866b-39b64f67c278.png)
<br/>

✨ ORDER BY 조건인 `selected_date`와 `created_at`으로 멀티 인덱싱하기 전에 더 좋은 방법은 없을까 생각을 해봤습니다.  
현재 상황은 지정한 날짜(selected_date)로 먼저 정렬하고, 지정 날짜가 같은 경우는 게시글이 생성된 시간으로 정렬하게 되는데,  
게시글 생성시간(created_at)으로 정렬하는 것과 **PK(auto_increment)** 값인 `post_id`로 정렬하는 것이 결국 같다는 것을 캐치하고,  
일단 테스트를 진행했습니다.
<br/>

#### 1. `selected_date`와 `created_at` 칼럼으로 멀티 인덱싱
![image](https://user-images.githubusercontent.com/60170616/160565452-2d14ef42-e6b6-4f4a-b0ac-33a00e38c69d.png)
- 인덱스 타는 것 확인
![image](https://user-images.githubusercontent.com/60170616/160565881-56ebb402-1e3b-4afd-9295-c16652a896de.png)
- 44.7초 -> 0.03초 확인!!
![image](https://user-images.githubusercontent.com/60170616/160566300-a4acf6d2-b9e7-43ce-b93a-fb2d2a344917.png)

#### 2. ORDER BY 조건을 created_at 대신 PK 값으로 수정하고, `selected_date`만 인덱스로 등록
- ORDER BY 조건만 일단 PK값으로 수정했을때, using temporary 옵션은 제거되고 전체 데이터를 filesort 합니다.
![image](https://user-images.githubusercontent.com/60170616/160567039-2307a572-96e4-48de-9fba-7eb9a9bc1125.png)
- `selected_date` 단일 인덱스 등록
![image](https://user-images.githubusercontent.com/60170616/160567660-4234cc30-a5db-4767-ba51-6287ee818c90.png)
- 인덱스 타는 것 확인
![image](https://user-images.githubusercontent.com/60170616/160567847-2ec3d93a-1500-44e2-93f6-7394295f177f.png)
- 44.7초 -> 0.016초 확인!!!!
![image](https://user-images.githubusercontent.com/60170616/160568119-253be48a-f164-4232-aa3f-632fdb7a65f2.png)

## 결론
> 단일 인덱스와 PK로 ORDER BY 정렬하는 것이 더 빠르기도 하고,  
> 인덱스를 관리하기에도 좋겠다고 판단하여 selected_date 단일 인덱스로 설정했습니다!
