### PR TITLE
RequestRejectedException 예외 핸들링

### DIFF
--- a/src/main/java/org/ahpuh/surf/common/aop/FilterChainProxyAdvice.java
+++ b/src/main/java/org/ahpuh/surf/common/aop/FilterChainProxyAdvice.java
@@ -1,0 +1,24 @@
+package org.ahpuh.surf.common.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Aspect
+@Component
+public class FilterChainProxyAdvice {
+
+    @Around("execution(public void org.springframework.security.web.FilterChainProxy.doFilter(..))")
+    public void handleRequestRejectedException(final ProceedingJoinPoint pjp) throws Throwable {
+        try {
+            pjp.proceed();
+        } catch (final RequestRejectedException exception) {
+            final HttpServletResponse response = (HttpServletResponse) pjp.getArgs()[1];
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}


### PR DESCRIPTION
## 📄 Description

- close : #209 

> URI path에 더블 슬래시(오타)가 입력되면 RequestRejectedException을 던지고 default로 500 응답을 보냅니다.
> 이를 400 응답으로 변환하기 위해 aop를 생성했습니다.

## 📌 구현 내용

- [x] RequestRejectedException AOP 생성

## ✅ PR 포인트

- 변경 전
![image](https://user-images.githubusercontent.com/60170616/161071653-db562907-a43e-499e-b780-acd80c8d14ac.png)
- 변경 후
![image](https://user-images.githubusercontent.com/60170616/161071700-866f9599-c0af-4d7a-a8a2-fec2b8a959ba.png)

## References
- https://github.com/spring-projects/spring-security/issues/5007
- https://stackoverflow.com/questions/51788764/how-to-intercept-a-requestrejectedexception-in-spring/55420714#55420714
