### PR TITLE
잘못된 URI path 예외 핸들링 처리

### DIFF
--- a/src/main/java/org/ahpuh/surf/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/ahpuh/surf/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.net.BindException;
 
@@ -31,6 +32,17 @@ public class GlobalExceptionHandler {
         log.warn(LOG_FORMAT, e.getClass().getSimpleName(), errorMessage);
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
+                .body(new ErrorResponse(errorMessage));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<Object> handleNoHandlerFoundException(
+            final NoHandlerFoundException e
+    ) {
+        final String errorMessage = e.getMessage();
+        log.warn(LOG_FORMAT, e.getClass().getSimpleName(), errorMessage);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(errorMessage));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
   profiles:
     group:
       "local": "console-logging,http-console-logging"


### PR DESCRIPTION
## 📄 Description

- close : #211 

> 잘못된 URI path로 요청시 404 NOT FOUND 응답이 보내지게 되는데,
> Bad Request로 수정하고 예외를 직접 custom 하도록 수정합니다.

## 📌 구현 내용

- [x] NoHandlerFoundException가 발생하도록 수정
- [x] Global 예외 핸들링에 추가

## ✅ PR 포인트

- 기존 응답 404 Not Found
  - 404 응답은 리소스를 못찾았을때 주로 사용한다.  
    존재하지 않는 api에 ResourceHttpRequestHandler가 매핑되고, 리소스가 존재하지 않았기 때문에 404 응답이 온 것.
![image](https://user-images.githubusercontent.com/60170616/161117958-86edbf50-9775-4cf3-807a-38804064a315.png)
- ResourceHandler 매핑 끄기
  ```yml
  spring.web.resources.add-mappings=false
  ```
- 이제는 PageNotFound 예외가 발생한다.
![image](https://user-images.githubusercontent.com/60170616/161119322-70439d84-f9fd-4ad0-aa37-5ec40bc1410c.png)
  - noHandlerFound() 를 타서 PageNotFound 로그가 찍힌것이다.
![image](https://user-images.githubusercontent.com/60170616/161119886-6b4fde32-24dd-4979-89ba-e929b6d01f0a.png)
  - 하지만 `this.throwExceptionIfNoHandlerFound`는 default가 false라서  
    NoHandlerFoundException 예외가 발생하지 않았다.
![image](https://user-images.githubusercontent.com/60170616/161121533-31575080-a798-4591-b954-9032ba1b70c1.png)
- throwExceptionIfNoHandlerFound을 true로 설정
  ```yml
  spring.mvc.throw-exception-if-no-handler-found=true
  ```
- NoHandlerFoundException 예외가 발생한다.
![image](https://user-images.githubusercontent.com/60170616/161121660-0c3cb91d-7946-438e-b637-931c60a7d99c.png)
- `@RestControllerAdvice`에서 NoHandlerFoundException 예외를 핸들링하면 된다!
![image](https://user-images.githubusercontent.com/60170616/161122489-df135224-b6f9-41bb-ba54-b76325e19c17.png)

## Reference
- https://tecoble.techcourse.co.kr/post/2021-11-24-spring-customize-unhandled-api