### PR TITLE
JACOCO 설정 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### RestDocs ###
 src/main/resources/static/docs/**
+
+### Jacoco Reports ###
+src/main/resources/static/reports/**

--- a/build.gradle
+++ b/build.gradle
@@ -121,13 +121,18 @@ jacocoTestReport {
         csv.enabled false
     }
 
+    def QClass = []
+    for (qPattern in "**/QA".."**/QZ") {
+        QClass.add(qPattern + "*")
+    }
+
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,
                     exclude: [
                             "**/SurfApplication*",
                             "**/S3ServiceImpl*"
-                    ])
+                    ] + QClass)
         }))
     }
     finalizedBy 'jacocoTestCoverageVerification'
@@ -148,7 +153,7 @@ jacocoTestCoverageVerification {
             excludes = [
                     '**.SurfApplication*',
                     '**.S3ServiceImpl*'
-            ]
+            ] + QClass
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,8 @@ jacocoTestReport {
             fileTree(dir: it,
                     exclude: [
                             "**/SurfApplication*",
-                            "**/S3ServiceImpl*"
+                            "**/S3ServiceImpl*",
+                            '**/dto*'
                     ] + QClass)
         }))
     }
@@ -139,6 +140,11 @@ jacocoTestReport {
 }
 
 jacocoTestCoverageVerification {
+    def QClass = []
+    for (qPattern in '*.QA'..'*.QZ') {
+        QClass.add(qPattern + '*')
+    }
+
     violationRules {
         rule {
             enabled = true
@@ -152,7 +158,8 @@ jacocoTestCoverageVerification {
 
             excludes = [
                     '**.SurfApplication*',
-                    '**.S3ServiceImpl*'
+                    '**.S3ServiceImpl*',
+                    '**.dto*'
             ] + QClass
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -163,4 +163,15 @@ jacocoTestCoverageVerification {
             ] + QClass
         }
     }
+    finalizedBy 'copyReports'
+}
+
+jacocoTestReport.doFirst {
+    delete file('src/main/resources/static/reports')
+}
+
+task copyReports(type: Copy) {
+    dependsOn('jacocoTestCoverageVerification')
+    from file("build/reports/jacoco/test/html")
+    into file("src/main/resources/static/reports")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'COVEREDRATIO'
-                minimum = 0.80
+                minimum = 0.85
             }
 
             excludes = [


### PR DESCRIPTION
## 📄 Description

- close : #218 

> JACOCO exclude 설정을 수정합니다.
> JACOCO reports를 `src/main/resources/static/reports`로 복사하도록 설정합니다.

## 📌 구현 내용

- [x] QClass 제외
- [x] DTO 제외
- [x] Minimum 테스트 커버리지 수정 [0.80 -> 0.85]
- [x] Jacoco reports 복사 설정 추가
> 현재 테스트 커버리지 : `93%`
