### PR TITLE
코드 리팩토링

### DIFF
--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -31,8 +31,8 @@ public class Category extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "is_public", nullable = false)
-    private Boolean isPublic;
+    @Column(name = "is_public", nullable = false, columnDefinition = "boolean default true")
+    private Boolean isPublic = true;
 
     @Column(name = "color_code")
     private String colorCode;
@@ -42,16 +42,14 @@ public class Category extends BaseEntity {
     private User user;
 
     @OneToMany(mappedBy = "category", fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Post> posts;
+    private final List<Post> posts = new ArrayList<>();
 
     @Builder
     public Category(final User user, final String name, final String colorCode) {
         this.user = user;
         this.name = name;
         this.colorCode = colorCode;
-        isPublic = true;
-        posts = new ArrayList<>();
-        user.addCategory(this);
+        user.getCategories().add(this);
     }
 
     public void update(final String name, final boolean isPublic, final String colorCode) {

--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -44,9 +44,6 @@ public class Category extends BaseEntity {
     @OneToMany(mappedBy = "category", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Post> posts;
 
-//    @Formula("(select count(1) from posts p where p.category_id = category_id and p.is_deleted = false)")
-//    private int postCount;
-
     @Builder
     public Category(final User user, final String name, final String colorCode) {
         this.user = user;

--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -13,7 +13,6 @@ import org.hibernate.annotations.Where;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -56,12 +55,5 @@ public class Category extends BaseEntity {
         this.name = name;
         this.isPublic = isPublic;
         this.colorCode = colorCode;
-    }
-
-    public void addPost(final Post post) {
-        if (Objects.isNull(posts)) {
-            posts = new ArrayList<>();
-        }
-        posts.add(post);
     }
 }

--- a/src/main/java/org/ahpuh/surf/category/domain/Category.java
+++ b/src/main/java/org/ahpuh/surf/category/domain/Category.java
@@ -40,7 +40,7 @@ public class Category extends BaseEntity {
     @JoinColumn(name = "user_id", referencedColumnName = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "category", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "category", orphanRemoval = true)
     private final List<Post> posts = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/ahpuh/surf/follow/domain/Follow.java
+++ b/src/main/java/org/ahpuh/surf/follow/domain/Follow.java
@@ -38,7 +38,7 @@ public class Follow {
     public Follow(final User source, final User target) {
         this.source = source;
         this.target = target;
-        source.addFollowing(this);
-        target.addFollowers(this);
+        source.getFollowing().add(this);
+        target.getFollowers().add(this);
     }
 }

--- a/src/main/java/org/ahpuh/surf/like/domain/Like.java
+++ b/src/main/java/org/ahpuh/surf/like/domain/Like.java
@@ -39,7 +39,7 @@ public class Like {
     public Like(final User user, final Post post) {
         this.user = user;
         this.post = post;
-        user.addLike(this);
-        post.addLike(this);
+        user.getLikes().add(this);
+        post.getLikes().add(this);
     }
 }

--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -18,7 +18,6 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -95,12 +94,5 @@ public class Post extends BaseEntity {
             throw new FavoriteInvalidUserException();
         }
         favorite = !favorite;
-    }
-
-    public void addLike(final Like like) {
-        if (Objects.isNull(likes)) {
-            likes = new ArrayList<>();
-        }
-        likes.add(like);
     }
 }

--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -56,11 +56,11 @@ public class Post extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 
-    @Column(name = "favorite")
-    private Boolean favorite;
+    @Column(name = "favorite", columnDefinition = "boolean default false")
+    private Boolean favorite = false;
 
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Like> likes;
+    private final List<Like> likes = new ArrayList<>();
 
     @Builder
     public Post(final User user, final Category category, final LocalDate selectedDate, final String content, final int score) {
@@ -69,10 +69,8 @@ public class Post extends BaseEntity {
         this.selectedDate = selectedDate;
         this.content = content;
         this.score = score;
-        favorite = false;
-        likes = new ArrayList<>();
-        user.addPost(this);
-        category.addPost(this);
+        user.getPosts().add(this);
+        category.getPosts().add(this);
     }
 
     public void updatePost(final Category category, final LocalDate selectedDate, final String content, final int score) {

--- a/src/main/java/org/ahpuh/surf/post/domain/Post.java
+++ b/src/main/java/org/ahpuh/surf/post/domain/Post.java
@@ -58,7 +58,7 @@ public class Post extends BaseEntity {
     @Column(name = "favorite", columnDefinition = "boolean default false")
     private Boolean favorite = false;
 
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private final List<Like> likes = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -1,6 +1,9 @@
 package org.ahpuh.surf.user.domain;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.ahpuh.surf.category.domain.Category;
 import org.ahpuh.surf.common.domain.BaseEntity;
 import org.ahpuh.surf.common.exception.user.InvalidPasswordException;
@@ -23,7 +26,6 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @SQLDelete(sql = "UPDATE users SET is_deleted = 1 WHERE user_id = ?")
 @Where(clause = "is_deleted = false")
 @Entity

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -60,19 +60,19 @@ public class User extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private Permission permission = Permission.ROLE_USER;
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     private final List<Category> categories = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     private final List<Post> posts = new ArrayList<>();
 
-    @OneToMany(mappedBy = "source", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "source", orphanRemoval = true)
     private final List<Follow> following = new ArrayList<>(); // 내가 팔로잉한
 
-    @OneToMany(mappedBy = "target", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "target", orphanRemoval = true)
     private final List<Follow> followers = new ArrayList<>(); // 나를 팔로우한
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     private final List<Like> likes = new ArrayList<>();
 
     @Formula("(select count(1) from follow f where f.user_id = user_id)")

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -113,39 +113,4 @@ public class User extends BaseEntity {
         this.accountPublic = request.getAccountPublic();
         profilePhotoUrl.ifPresent(s -> this.profilePhotoUrl = s);
     }
-
-    public void addCategory(final Category category) {
-        if (Objects.isNull(categories)) {
-            categories = new ArrayList<>();
-        }
-        categories.add(category);
-    }
-
-    public void addPost(final Post post) {
-        if (Objects.isNull(posts)) {
-            posts = new ArrayList<>();
-        }
-        posts.add(post);
-    }
-
-    public void addFollowing(final Follow followingUser) {
-        if (Objects.isNull(following)) {
-            following = new ArrayList<>();
-        }
-        following.add(followingUser);
-    }
-
-    public void addFollowers(final Follow follower) {
-        if (Objects.isNull(followers)) {
-            followers = new ArrayList<>();
-        }
-        followers.add(follower);
-    }
-
-    public void addLike(final Like like) {
-        if (Objects.isNull(likes)) {
-            likes = new ArrayList<>();
-        }
-        likes.add(like);
-    }
 }

--- a/src/main/java/org/ahpuh/surf/user/domain/User.java
+++ b/src/main/java/org/ahpuh/surf/user/domain/User.java
@@ -54,26 +54,26 @@ public class User extends BaseEntity {
     private String aboutMe;
 
     @Column(name = "account_public", columnDefinition = "boolean default true")
-    private Boolean accountPublic;
+    private Boolean accountPublic = true;
 
     @Column(name = "permission")
     @Enumerated(value = EnumType.STRING)
-    private Permission permission;
+    private Permission permission = Permission.ROLE_USER;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Category> categories;
+    private final List<Category> categories = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Post> posts;
+    private final List<Post> posts = new ArrayList<>();
 
     @OneToMany(mappedBy = "source", fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Follow> following; // 내가 팔로잉한
+    private final List<Follow> following = new ArrayList<>(); // 내가 팔로잉한
 
     @OneToMany(mappedBy = "target", fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Follow> followers; // 나를 팔로우한
+    private final List<Follow> followers = new ArrayList<>(); // 나를 팔로우한
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Like> likes;
+    private final List<Like> likes = new ArrayList<>();
 
     @Formula("(select count(1) from follow f where f.user_id = user_id)")
     private int followingCount;
@@ -86,13 +86,6 @@ public class User extends BaseEntity {
         this.email = email;
         this.password = password;
         this.userName = userName;
-        accountPublic = true;
-        permission = Permission.ROLE_USER;
-        categories = new ArrayList<>();
-        posts = new ArrayList<>();
-        following = new ArrayList<>();
-        followers = new ArrayList<>();
-        likes = new ArrayList<>();
     }
 
     public boolean checkPassword(final PasswordEncoder passwordEncoder, final String credentials) {

--- a/src/test/java/org/ahpuh/surf/common/factory/MockUserFactory.java
+++ b/src/test/java/org/ahpuh/surf/common/factory/MockUserFactory.java
@@ -1,14 +1,11 @@
 package org.ahpuh.surf.common.factory;
 
-import org.ahpuh.surf.user.domain.Permission;
 import org.ahpuh.surf.user.domain.User;
 import org.ahpuh.surf.user.dto.request.UserJoinRequestDto;
 import org.ahpuh.surf.user.dto.request.UserLoginRequestDto;
 import org.ahpuh.surf.user.dto.request.UserUpdateRequestDto;
 import org.ahpuh.surf.user.dto.response.UserFindInfoResponseDto;
 import org.ahpuh.surf.user.dto.response.UserLoginResponseDto;
-
-import java.util.ArrayList;
 
 public class MockUserFactory {
 
@@ -34,46 +31,6 @@ public class MockUserFactory {
                 .password(password)
                 .userName(userName)
                 .build();
-    }
-
-    public static User createSavedUser() {
-        return new User(1L,
-                "mock",
-                "test1@naver.com",
-                "$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG",
-                null,
-                null,
-                null,
-                true,
-                Permission.ROLE_USER,
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                0,
-                0
-        );
-    }
-
-    public static User createSavedUserWithProfileImage() {
-        return new User(1L,
-                "mock",
-                "test1@naver.com",
-                "$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG",
-                "profilePhoto",
-                null,
-                null,
-                true,
-                Permission.ROLE_USER,
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                new ArrayList<>(),
-                0,
-                0
-        );
     }
 
     public static UserJoinRequestDto createUserJoinRequestDto() {

--- a/src/test/java/org/ahpuh/surf/integration/user/service/UserServiceIntegrationTest.java
+++ b/src/test/java/org/ahpuh/surf/integration/user/service/UserServiceIntegrationTest.java
@@ -153,7 +153,9 @@ public class UserServiceIntegrationTest extends IntegrationTest {
         @Test
         void updateUserWithProfileImageSuccess() {
             // Given
-            final User user = userRepository.save(createSavedUser());
+            final User user = userRepository.save(createMockUser("test1@naver.com",
+                    "$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG",
+                    "mock"));
             assertAll("유저 정보 변경전",
                     () -> assertThat(user.getUserName()).isEqualTo("mock"),
                     () -> assertThat(passwordEncoder.matches("testpw", user.getPassword())).isTrue(),
@@ -184,7 +186,9 @@ public class UserServiceIntegrationTest extends IntegrationTest {
         @Test
         void updateUserWithNoProfileImageSuccess() {
             // Given
-            final User user = userRepository.save(createSavedUser());
+            final User user = userRepository.save(createMockUser("test1@naver.com",
+                    "$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG",
+                    "mock"));
             assertAll("유저 정보 변경전",
                     () -> assertThat(user.getUserName()).isEqualTo("mock"),
                     () -> assertThat(passwordEncoder.matches("testpw", user.getPassword())).isTrue(),

--- a/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/category/domain/CategoryTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
-import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
+import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -16,7 +16,7 @@ public class CategoryTest {
     @Test
     void updateCategoryTest() {
         // Given
-        final User user = createSavedUser();
+        final User user = createMockUser();
         final Category category = createMockCategory(user);
 
         // When

--- a/src/test/java/org/ahpuh/surf/unit/jwt/JwtAuthenticationProviderTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/jwt/JwtAuthenticationProviderTest.java
@@ -4,6 +4,7 @@ import org.ahpuh.surf.jwt.Jwt;
 import org.ahpuh.surf.jwt.JwtAuthentication;
 import org.ahpuh.surf.jwt.JwtAuthenticationProvider;
 import org.ahpuh.surf.jwt.JwtAuthenticationToken;
+import org.ahpuh.surf.user.domain.Permission;
 import org.ahpuh.surf.user.domain.User;
 import org.ahpuh.surf.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -14,11 +15,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 
-import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class JwtAuthenticationProviderTest {
@@ -36,11 +37,17 @@ public class JwtAuthenticationProviderTest {
     @Test
     void authenticateTest() {
         // Given
-        final User user = createSavedUser();
+        final User user = mock(User.class);
         given(userService.login("cse0518", "password"))
                 .willReturn(user);
         given(jwt.sign(any()))
                 .willReturn("token");
+        given(user.getPermission())
+                .willReturn(Permission.ROLE_USER);
+        given(user.getUserId())
+                .willReturn(1L);
+        given(user.getEmail())
+                .willReturn("test@naver.com");
 
         // When
         final Authentication authentication

--- a/src/test/java/org/ahpuh/surf/unit/post/domain/PostTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/post/domain/PostTest.java
@@ -9,16 +9,17 @@ import org.ahpuh.surf.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.time.LocalDate;
 
 import static org.ahpuh.surf.common.factory.MockCategoryFactory.createMockCategory;
 import static org.ahpuh.surf.common.factory.MockPostFactory.createMockPost;
 import static org.ahpuh.surf.common.factory.MockUserFactory.createMockUser;
-import static org.ahpuh.surf.common.factory.MockUserFactory.createSavedUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
 
 public class PostTest {
 
@@ -92,13 +93,15 @@ public class PostTest {
         @Test
         void updateFavorite() {
             // Given
-            final User user = createSavedUser();
-            final Category category = createMockCategory(user);
+            final User user = Mockito.mock(User.class);
+            final Category category = Mockito.mock(Category.class);
             final Post post = createMockPost(user, category);
             assertThat(post.getFavorite()).isFalse();
+            given(user.getUserId())
+                    .willReturn(1L);
 
             // When
-            post.updateFavorite(user.getUserId());
+            post.updateFavorite(1L);
 
             // Then
             assertThat(post.getFavorite()).isTrue();
@@ -108,13 +111,15 @@ public class PostTest {
         @Test
         void favoriteUpdateFailException() {
             // Given
-            final User user = createSavedUser();
-            final Category category = createMockCategory(user);
+            final User user = Mockito.mock(User.class);
+            final Category category = Mockito.mock(Category.class);
             final Post post = createMockPost(user, category);
             assertThat(post.getFavorite()).isFalse();
+            given(user.getUserId())
+                    .willReturn(1L);
 
             // When Then
-            assertThatThrownBy(() -> post.updateFavorite(100L))
+            assertThatThrownBy(() -> post.updateFavorite(2L))
                     .isInstanceOf(FavoriteInvalidUserException.class)
                     .hasMessage("즐겨찾기를 등록 또는 취소할 수 없습니다.(내 게시글만 등록 가능)");
         }

--- a/src/test/java/org/ahpuh/surf/unit/user/domain/UserTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/user/domain/UserTest.java
@@ -23,12 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class UserTest {
 
-    private static final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
     private User mockUser;
 
     @BeforeEach
     void setUp() {
-        mockUser = createSavedUser();
+        mockUser = createMockUser("test1@naver.com",
+                "$2a$10$1dmE40BM1RD2lUg.9ss24eGs.4.iNYq1PwXzqKBfIXNRbKCKliqbG",
+                "mock");
     }
 
     @DisplayName("checkPassword 메소드는")
@@ -103,65 +105,45 @@ public class UserTest {
         @Test
         void updateUser_WIthPassword_NoProfileImage() {
             // Given
-            final User savedUser = createSavedUserWithProfileImage();
             final UserUpdateRequestDto updateRequest = createUserUpdateRequestDto();
-            final Optional<String> profilePhotoUrl = Optional.empty();
+            Optional<String> profilePhotoUrl = Optional.of("profilePhoto");
 
             // When
-            savedUser.update(passwordEncoder, updateRequest, profilePhotoUrl);
+            mockUser.update(passwordEncoder, updateRequest, profilePhotoUrl);
 
             // Then
             assertAll("수정된 유저 정보 검증_프로필이미지 X",
-                    () -> assertThat(savedUser.getUserName()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getUrl()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getAboutMe()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getAccountPublic()).isFalse(),
-                    () -> assertThat(passwordEncoder.matches("update", savedUser.getPassword())).isTrue(),
-                    () -> assertThat(savedUser.getProfilePhotoUrl()).isEqualTo("profilePhoto")
+                    () -> assertThat(mockUser.getUserName()).isEqualTo("update"),
+                    () -> assertThat(mockUser.getUrl()).isEqualTo("update"),
+                    () -> assertThat(mockUser.getAboutMe()).isEqualTo("update"),
+                    () -> assertThat(mockUser.getAccountPublic()).isFalse(),
+                    () -> assertThat(passwordEncoder.matches("update", mockUser.getPassword())).isTrue(),
+                    () -> assertThat(mockUser.getProfilePhotoUrl()).isEqualTo("profilePhoto")
             );
+
+            profilePhotoUrl = Optional.empty();
+            mockUser.update(passwordEncoder, updateRequest, profilePhotoUrl);
+            assertThat(mockUser.getProfilePhotoUrl()).isEqualTo("profilePhoto");
         }
 
         @DisplayName("비밀번호를 제외하고 프로필이미지를 포함한 유저 정보를 수정할 수 있다.")
         @Test
         void updateUser_WIthProfileImage_NoPassword() {
             // Given
-            final User savedUser = createSavedUserWithProfileImage();
             final UserUpdateRequestDto updateRequest = createUserUpdateRequestDtoWithNoPassword();
             final Optional<String> profilePhotoUrl = Optional.of("update");
 
             // When
-            savedUser.update(passwordEncoder, updateRequest, profilePhotoUrl);
+            mockUser.update(passwordEncoder, updateRequest, profilePhotoUrl);
 
             // Then
             assertAll("수정된 유저 정보 검증_비밀번호 X",
-                    () -> assertThat(savedUser.getUserName()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getUrl()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getAboutMe()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getAccountPublic()).isFalse(),
-                    () -> assertThat(passwordEncoder.matches("testpw", savedUser.getPassword())).isTrue(),
-                    () -> assertThat(savedUser.getProfilePhotoUrl()).isEqualTo("update")
-            );
-        }
-
-        @DisplayName("비밀번호와 프로필이미지는 변경하지 않고 나머지 유저 정보를 수정할 수 있다.")
-        @Test
-        void updateUser_NoPasswordAndProfileImage() {
-            // Given
-            final User savedUser = createSavedUserWithProfileImage();
-            final UserUpdateRequestDto updateRequest = createUserUpdateRequestDtoWithNoPassword();
-            final Optional<String> profilePhotoUrl = Optional.empty();
-
-            // When
-            savedUser.update(passwordEncoder, updateRequest, profilePhotoUrl);
-
-            // Then
-            assertAll("수정된 유저 정보 검증_비밀번호 X",
-                    () -> assertThat(savedUser.getUserName()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getUrl()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getAboutMe()).isEqualTo("update"),
-                    () -> assertThat(savedUser.getAccountPublic()).isFalse(),
-                    () -> assertThat(passwordEncoder.matches("testpw", savedUser.getPassword())).isTrue(),
-                    () -> assertThat(savedUser.getProfilePhotoUrl()).isEqualTo("profilePhoto")
+                    () -> assertThat(mockUser.getUserName()).isEqualTo("update"),
+                    () -> assertThat(mockUser.getUrl()).isEqualTo("update"),
+                    () -> assertThat(mockUser.getAboutMe()).isEqualTo("update"),
+                    () -> assertThat(mockUser.getAccountPublic()).isFalse(),
+                    () -> assertThat(passwordEncoder.matches("testpw", mockUser.getPassword())).isTrue(),
+                    () -> assertThat(mockUser.getProfilePhotoUrl()).isEqualTo("update")
             );
         }
     }

--- a/src/test/java/org/ahpuh/surf/unit/user/service/UserServiceTest.java
+++ b/src/test/java/org/ahpuh/surf/unit/user/service/UserServiceTest.java
@@ -138,7 +138,7 @@ public class UserServiceTest {
             given(userConverter.toEntity(joinRequestDto))
                     .willReturn(mockUser);
             given(userRepository.save(mockUser))
-                    .willReturn(createSavedUser());
+                    .willReturn(mockUser);
 
             // When
             userService.join(joinRequestDto);


### PR DESCRIPTION
## 📄 Description

- close : #220 

> 전체적인 코드 리팩토링

## 📌 구현 내용

- [x] 불필요한 주석 삭제
- [x] 필드 초기화를 생성자가 아닌 필드에서 바로 초기화하도록 수정
- [x] 연관관계 편의 메소드 삭제
- [x] OneToMany인 경우 Lazy fetch 옵션 제거(default가 Lazy)
- [x] User Entity 클래스에 AllArgsConstructor 삭제
- [x] 테스트 코드 수정

## ✅ PR 포인트

- 컬렉션은 필드레벨에서 초기화를 해주는게 가장 안전하다고 생각되어 필드 초기화로 수정했습니다.
- 연관관계 편의 메소드가 단순해져서 삭제하고, 필요한 곳에서 바로 로직을 수행하도록 수정했습니다.
- @ OneToMany 인 경우 default가 Lazy fetch이기 때문에 따로 Lazy fetch를 명시하지 않도록 수정했습니다.
- 변경사항에 맞게 테스크 코드를 수정했습니다.
